### PR TITLE
Add recyclerlistview version to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Check out [the Vault project](https://vault.shopify.io/projects/22845) to learn 
 
 ### Adding a package to your project
 
-Add the package to your project via `yarn add @shopify/recycler-flat-list recyclerlistview`, and run pod install in the `ios` directory.
+Add the package to your project via `yarn add @shopify/recycler-flat-list recyclerlistview@3.1.0-beta.1`, and run pod install in the `ios` directory.
 
 Note that [`recyclerlistview`](https://github.com/Flipkart/recyclerlistview) is a peer dependency of `@shopify/recycler-flat-list`
 


### PR DESCRIPTION
If you run `recycler-flat-list` with the latest non-beta version, you'll get the following error:

![image](https://user-images.githubusercontent.com/9371695/150516558-63e28db0-7bbf-4bc0-83da-aa9b4170a132.png)

We should use `3.1.0-beta.1` as it's defined in the [peerDependencies](https://github.com/Shopify/recycler-flat-list/blob/main/package.json#L34)
