### PR TITLE
Linked fixture with outer project

### DIFF
--- a/fixture/android/settings.gradle
+++ b/fixture/android/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'FlatListPro'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
+include ':recycler_flat_list'
+project(':recycler_flat_list').projectDir = new File(rootProject.projectDir, '../../android')


### PR DESCRIPTION
Fixes:

Android fixture doesn't link to the outer project so debugging android was an issue. A simple project link solves that.