### PR TITLE
Report negative numbers for blank area

### DIFF
--- a/ios/Sources/AutoLayoutView.swift
+++ b/ios/Sources/AutoLayoutView.swift
@@ -157,7 +157,7 @@ import UIKit
         let blankOffsetEnd = actualScrollOffset + windowSize - renderAheadOffset - filledBoundMax
 
         // one of the values is negative, we look for the positive one
-        let blankArea = max(0, blankOffsetStart, blankOffsetEnd)
+        let blankArea = max(blankOffsetStart, blankOffsetEnd)
 
         return (blankOffsetStart, blankOffsetEnd, blankArea)
     }


### PR DESCRIPTION
It's interesting to know how much ahead the rendering is instead of defaulting to 0. 