### PR TITLE
estimatedListSize was causing visible glitches

### DIFF
--- a/fixture/package.json
+++ b/fixture/package.json
@@ -17,7 +17,7 @@
     "react-native-gesture-handler": "^2.1.1",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.10.1",
-    "recyclerlistview": "3.1.0-beta.1"
+    "recyclerlistview": "3.1.0-beta.2"
   },
   "devDependencies": {
     "babel-plugin-module-resolver": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.10.1",
     "react-test-renderer": "17.0.2",
-    "recyclerlistview": "3.1.0-beta.1",
+    "recyclerlistview": "3.1.0-beta.2",
     "typescript": "^4.1.3"
   },
   "jest": {


### PR DESCRIPTION
In the profiling session I noticed that providing estimatedSize to RFL was leading to AutoLayout not working. I could see items moving here and there.

I debugged and figured out that renderContentContainer callback doesn't get the right window size when an early render is trigger due to layoutSize (first frame). The reason is that internal scrollview is still of size zero and hasn't mounted yet.

I've fixed the issue in RLV here (same PR for item container): https://github.com/Flipkart/recyclerlistview/pull/675/commits/2ea6492562cbcc53b6ac8ff98614a90c5485abf4