### PR TITLE
Pre build recycler pool to eliminate initial frame dips

### DIFF
--- a/fixture/package.json
+++ b/fixture/package.json
@@ -17,7 +17,7 @@
     "react-native-gesture-handler": "^2.1.1",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.10.1",
-    "recyclerlistview": "3.1.0-beta.2"
+    "recyclerlistview": "3.1.0-beta.3"
   },
   "devDependencies": {
     "babel-plugin-module-resolver": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.10.1",
     "react-test-renderer": "17.0.2",
-    "recyclerlistview": "3.1.0-beta.2",
+    "recyclerlistview": "3.1.0-beta.3",
     "typescript": "^4.1.3"
   },
   "jest": {

--- a/src/RecyclerFlatList.tsx
+++ b/src/RecyclerFlatList.tsx
@@ -11,6 +11,7 @@ import {
   DataProvider,
   GridLayoutProvider,
   LayoutProvider,
+  ProgressiveListView,
   RecyclerListView,
   RecyclerListViewProps,
 } from "recyclerlistview";
@@ -42,9 +43,11 @@ class RecyclerFlatList<T> extends React.PureComponent<
   private rlvRef?: RecyclerListView<RecyclerListViewProps, any>;
   private listFixedDimensionSize = 0;
 
-  static props = {
+  static defaultProps = {
     data: [],
   };
+
+  static readonly RENDER_AHEAD_OFFSET = 250;
 
   constructor(props) {
     super(props);
@@ -153,7 +156,7 @@ class RecyclerFlatList<T> extends React.PureComponent<
       }
 
       return (
-        <RecyclerListView
+        <ProgressiveListView
           ref={this.recyclerRef}
           layoutProvider={this.state.layoutProvider}
           style={style as object}
@@ -170,6 +173,9 @@ class RecyclerFlatList<T> extends React.PureComponent<
           onEndReachedThreshold={this.props.onEndReachedThreshold || undefined}
           extendedState={this.props.extraData}
           layoutSize={this.props.estimatedListSize}
+          maxRenderAhead={3 * RecyclerFlatList.RENDER_AHEAD_OFFSET}
+          finalRenderAheadOffset={RecyclerFlatList.RENDER_AHEAD_OFFSET}
+          renderAheadStep={RecyclerFlatList.RENDER_AHEAD_OFFSET}
         />
       );
     }


### PR DESCRIPTION
# What
This PR switches rendering to `ProgressiveListView` to build recycler item pool in advance. It's an extension to RLV that supports progressive rendering. It starts drawing whatever fits the screen and then increments draw distance to match `maxRenderAhead` value that we can provide.
I added a feature to the progressive version where it can set a `finalRenderAheadOffset` (extra draw distance). Check the PR here: https://github.com/Flipkart/recyclerlistview/pull/685/files
So, this PR switches to progressivelist and also modifies `maxRenderAhead` and final value. 

# Why
- By drawing incrementally we will improve the first load time. First frame will only draw visible content. Next frame will add buffer for scrolling. Both happen in the same frame today.
- We're setting a smaller `finalRenderAheadOffset` value which mean that items drawn between this value and `maxRenderAhead` will act as recycle pool leading to improved first scroll performance

### Pros
- The value combination used is working well in phones and I was able to scroll down 1200 tweets without a single dropped frame
- Load time is faster compared to previous implementation consistently.  On my emulator it went down to 50 ms from about 80ms

### Cons
- We're drawing more items on load so memory consumption will be higher at the start. Count is still a fraction of what FlatList mounts.
- There's no good way to predict the value to use. Minimum that I found working well is 750 for max render. This mean items occupying around 500dp will move to pool on start.

## Doubts
A huge single list isn't representative of real world use case where mostly data is loaded through pagination. With pagination there is enough time to build the pool anyway before anyone can actually scroll quickly. We should definitely use progressive list but I'm not sure with what max render value. We can keep it configurable for advanced users but not sure about defaults.

## Demo
Took the video with camera. Screen recorder was impacting perf and I was trying to see if we can avoid all frame drops in an ideal setting. **Notice after the initial page load there are no frame drops at all.** Stuck to 45 even after multiple scrolls.

https://user-images.githubusercontent.com/7811728/151406829-2a64c475-f685-451a-955d-e9cabd997cde.mp4



