### PR TITLE
Link to code source directly instead of transpiled source

### DIFF
--- a/.shopify-build/recycler-flat-list.yml
+++ b/.shopify-build/recycler-flat-list.yml
@@ -11,6 +11,5 @@ steps:
   - label: "Lint Typescript :eslint:"
     timeout: 20m
     run:
-      - yarn:
-          workspaces: true
+      - yarn
       - yarn lint

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "shopify",
   "license": "MIT",
   "homepage": "https://github.com/shopify/recycler-flat-list#readme",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/shipit.yml
+++ b/shipit.yml
@@ -5,7 +5,3 @@ ci:
 dependencies:
   override:
     - yarn install
-
-deploy:
-  pre:
-    - yarn run build

--- a/src/RecyclerFlatList.tsx
+++ b/src/RecyclerFlatList.tsx
@@ -317,7 +317,6 @@ class RecyclerFlatList<T> extends React.PureComponent<
       ListHeaderComponent.props = { style };
       return ListHeaderComponent;
     } else if (ListHeaderComponent != null) {
-      console.log(style);
       return <ListHeaderComponent style={style} />;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/Shopify/recycler-flat-list/issues/55

Instead of linking to the `dist` folder from `package.json`, let's link to the code source directly, so it's easier to debug the code - this will be useful during pairings. 