### PR TITLE
ignoring cached layouts

### DIFF
--- a/src/GridLayoutProviderWithProps.ts
+++ b/src/GridLayoutProviderWithProps.ts
@@ -54,6 +54,8 @@ export default class GridLayoutProviderWithProps<T> extends GridLayoutProvider {
     isHorizontal?: boolean,
     cachedLayouts?: Layout[]
   ): LayoutManager {
+    // Cached layouts lead to some visible resizing on orientation change when Grid Layout Provider is used. Ignoring caches.
+    // This won't hurt performance much and is only used while resizing.
     return super.newLayoutManager(renderWindowSize, isHorizontal);
   }
 


### PR DESCRIPTION
Whenever list changes size RLV attempts to reuse some of the cached layout. It's not really necessary and with GridLayoutProvider I observed some bugs on orientation change. I'm override our own derivation to ignore caches.