### PR TITLE
moving to class and enabling instance level on blank

### DIFF
--- a/src/AutoLayoutView.tsx
+++ b/src/AutoLayoutView.tsx
@@ -38,13 +38,18 @@ class AutoLayoutView extends React.Component<AutoLayoutViewProps> {
       offsetStart: nativeEvent.offsetStart,
       offsetEnd: nativeEvent.offsetEnd,
     };
-    listeners.forEach((listener) => {
-      listener(blankEventValue);
-    });
+    this.broadcastBlankEvent(blankEventValue);
     if (this.props.onBlankAreaEvent) {
       this.props.onBlankAreaEvent(blankEventValue);
     }
   };
+
+  private broadcastBlankEvent(value: BlankAreaEvent) {
+    const len = listeners.length;
+    for (let i = 0; i < len; i++) {
+      listeners[i](value);
+    }
+  }
 
   render() {
     return (


### PR DESCRIPTION
Changed AutoLayout to class component to avoid creating closure in the critical render path.
Also, enabled instance level onBlankEvents