### PR TITLE
Render on data change

### DIFF
--- a/src/RecyclerFlatList.tsx
+++ b/src/RecyclerFlatList.tsx
@@ -86,8 +86,14 @@ export interface RecyclerFlatListState<T> {
   numColumns: number;
   layoutProvider: GridLayoutProviderWithProps<RecyclerFlatListProps<T>>;
   data?: ReadonlyArray<T> | null;
+  extraData?: ExtraData<unknown>;
 }
 
+interface ExtraData<T> {
+  value?: T;
+}
+
+// eslint-disable-next-line @shopify/react-initialize-state
 class RecyclerFlatList<T> extends React.PureComponent<
   RecyclerFlatListProps<T>,
   RecyclerFlatListState<T>
@@ -103,9 +109,6 @@ class RecyclerFlatList<T> extends React.PureComponent<
   constructor(props) {
     super(props);
     this.setup();
-
-    // eslint-disable-next-line react/state-in-constructor
-    this.state = RecyclerFlatList.getDerivedStateFromProps(props, undefined);
   }
 
   private setup() {
@@ -143,6 +146,10 @@ class RecyclerFlatList<T> extends React.PureComponent<
       newState.dataProvider = oldState.dataProvider.cloneWithRows(
         nextProps.data as any[]
       );
+      newState.extraData = { ...oldState.extraData };
+    }
+    if (nextProps.extraData !== oldState.extraData?.value) {
+      newState.extraData = { value: nextProps.extraData };
     }
     newState.layoutProvider.updateProps(nextProps);
     return newState;
@@ -253,7 +260,7 @@ class RecyclerFlatList<T> extends React.PureComponent<
           renderContentContainer={this.container}
           onEndReached={this.onEndReached}
           onEndReachedThreshold={this.props.onEndReachedThreshold || undefined}
-          extendedState={this.props.extraData}
+          extendedState={this.state.extraData}
           layoutSize={this.props.estimatedListSize}
           maxRenderAhead={3 * drawDistance}
           finalRenderAheadOffset={drawDistance}
@@ -348,7 +355,7 @@ class RecyclerFlatList<T> extends React.PureComponent<
     const elem = this.props.renderItem?.({
       item: data,
       index,
-      extraData,
+      extraData: extraData?.value,
     } as any);
     let elements = [this.header(index), elem];
 


### PR DESCRIPTION
resolves #116 

Please check the issue for more details.

Summary: FlatList always renders all cells if any prop of list changes but it does advice to use extraData if developers want to trigger rerender. To make our list similar we will now rerender cells if data on list changes. We're still not going trigger rerenders on all prop change because that can lead to unexpected slowdowns. We can wait to see if this approach leads to any new issues.