### PR TITLE
add initialRenderIndex prop

### DIFF
--- a/src/RecyclerFlatList.tsx
+++ b/src/RecyclerFlatList.tsx
@@ -258,6 +258,7 @@ class RecyclerFlatList<T> extends React.PureComponent<
           maxRenderAhead={3 * drawDistance}
           finalRenderAheadOffset={drawDistance}
           renderAheadStep={drawDistance}
+          initialRenderIndex={this.props.initialScrollIndex || undefined}
           {...this.props.overrideProps}
         />
       );


### PR DESCRIPTION
## What

Map FlatList's [`initialRenderIndex` prop](https://reactnative.dev/docs/flatlist#initialscrollindex) into RecyclerFlatList's `initialScrollIndex` prop

I've noticed that scroll works incorrectly though - scroll starts not with a cell's top, but in the middle of it. Might be that it happens because of a header, what do you think @naqvitalha? 

## Video

An example of scroll with incorrect scroll offset: 

https://user-images.githubusercontent.com/6910688/155289222-e9cf9742-1607-45fc-b597-554d92770181.mp4


