### PR TITLE
Added support for progressViewOffset prop

### DIFF
--- a/src/RecyclerFlatList.tsx
+++ b/src/RecyclerFlatList.tsx
@@ -232,6 +232,7 @@ class RecyclerFlatList<T> extends React.PureComponent<
         const refreshControl = (
           <RefreshControl
             refreshing={this.props.refreshing as boolean}
+            progressViewOffset={this.props.progressViewOffset}
             onRefresh={this.props.onRefresh}
           />
         );


### PR DESCRIPTION
# Description
Adds support for` progressViewOffset`. It's actually a prop of `RefreshControl` that FlatList just forwards. I've implemented it the same way. It can be used to shift where the loading indicator appears.