### PR TITLE
Bug fix for style and last separator

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -171,6 +171,8 @@ class FlashList<T> extends React.PureComponent<
     if (Number(this.props.numColumns) > 1 && this.props.horizontal) {
       throw new CustomError(ExceptionList.columnsWhileHorizontalNotSupported);
     }
+
+    // `createAnimatedComponent` always passes a blank style object. To avoid warning while using AnimatedFlashList we've modified the check
     if (Object.keys(this.props.style || {}).length > 0) {
       console.warn(WarningList.styleUnsupported);
     }


### PR DESCRIPTION
# What
While doing sticky headers I made a mistake and set flexDirection as row when items are in a horizontal list. Because of this if developers set `flex:1` on their items `flexBox` can run into issues. The reason for this is width of items is unknown in a horizontal list and flex:1 has no reference. To solve this the direction should be column in this mode.

I realized this while testing this in POS Carousal. Other fixes:
1) Separator for last item removed
2) Animated version of list always passes an empty style object. That's how createAnimatedComponent works. I've handled this now.