### PR TITLE
Add changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,8 +11,11 @@ Please include a summary of what you want to achieve in this pull request. Remem
 <!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->
 
 - [ ]
-- [ ]
 
 ## Screenshots or videos (if needed)
 
 <!-- Showcase the working feature to make testing easier. -->
+
+## Checklist
+
+- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2022-03-08
+
+- Rename the component from `RecyclerFlatList` to `FlashList`
+  - https://github.com/Shopify/flash-list/pull/140
+
+## [0.1.0] - 2022-03-02
+
+- Initial release


### PR DESCRIPTION
We don't have a `CHANGELOG` tracking changes, so users know what they can find in the latest release. As we plan to ask our internal teams to try out the library, we should also start adding logs to our `CHANGELOG`.

Additionally, the PR template was in a mistyped directory, so I have corrected that.