### PR TITLE
Revert react-native-safe-area upgrade and minSdkVersion bump

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,10 +5,10 @@ apply plugin: 'kotlin-android'
 def _ext = rootProject.ext
 
 def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
-def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 31
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 30
 def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '30.0.2'
-def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 24
-def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 31
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 21
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 30
 def _kotlinVersion = _ext.has('kotlinVersion') ? _ext.kotlinVersion : '1.5.30'
 def _junitVersion = _ext.has('junitVersion') ? _ext.junitVersion : '4.13.2'
 def _mockitoVersion = _ext.has('mockitoVersion') ? _ext.mockitoVersion : '3.2.0'

--- a/fixture/android/app/src/debug/AndroidManifest.xml
+++ b/fixture/android/app/src/debug/AndroidManifest.xml
@@ -8,6 +8,6 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="true"/>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>

--- a/fixture/android/app/src/main/AndroidManifest.xml
+++ b/fixture/android/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize"
-        android:exported="true">
+        android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/fixture/android/build.gradle
+++ b/fixture/android/build.gradle
@@ -3,11 +3,11 @@
 buildscript {
     ext {
         buildToolsVersion = "30.0.2"
-        minSdkVersion = 24
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        minSdkVersion = 21
+        compileSdkVersion = 30
+        targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
-        kotlin_version = "1.5.30"
+        kotlin_version = "1.4.10"
 
     }
     repositories {

--- a/fixture/package.json
+++ b/fixture/package.json
@@ -18,7 +18,7 @@
     "react-native-fast-image": "^8.5.11",
     "react-native-flipper": "^0.138.0",
     "react-native-gesture-handler": "^2.3.2",
-    "react-native-safe-area-context": "^4.1.2",
+    "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.13.1",
     "recyclerlistview": "3.1.0-beta.6",
     "@shopify/flash-list": "link:../"

--- a/fixture/yarn.lock
+++ b/fixture/yarn.lock
@@ -3956,10 +3956,10 @@ react-native-gesture-handler@^2.3.2:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
-react-native-safe-area-context@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.1.2.tgz#2433715c568550f29ae768f8ca7b561f99b5230c"
-  integrity sha512-35hLhtJRCZW0L2zTz0Wz3d0Oh6uYUiRWa/HvoITq7IvD8GkjjM97MKHSfVhC4N9ZNMzqXDuVfYBpHHisc9Z8+Q==
+react-native-safe-area-context@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.3.2.tgz#9549a2ce580f2374edb05e49d661258d1b8bcaed"
+  integrity sha512-yOwiiPJ1rk+/nfK13eafbpW6sKW0jOnsRem2C1LPJjM3tfTof6hlvV5eWHATye3XOpu2cJ7N+HdkUvUDGwFD2Q==
 
 react-native-screens@^3.13.1:
   version "3.13.1"


### PR DESCRIPTION
## Description

Reverts react-native-safe-area upgrade and minSdkVersion bump to unblock Shopify Mobile Payouts

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
