### PR TITLE
Add missing versions to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,30 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Fixed distributing untranspiled library code by enforcing stricters TS rules.
+## [0.3.0] - 2022-03-15
 
+- Fixed untranspiled library code by enforcing stricter TS rules.
   - https://github.com/Shopify/flash-list/pull/181
+
+## [0.2.4] - 2022-03-14
 
 - Added `onLoad` event that is called once the list has rendered items. This is required because FlashList doesn't render items in the first cycle.
   - https://github.com/Shopify/flash-list/pull/180
+
+## [0.2.3] - 2022-03-10
+
+- Fixing publish steps for transpiled code
+  - https://github.com/Shopify/flash-list/pull/150
+
+## [0.2.2] - 2022-03-10
+
+- Fixing publish steps for transpiled code
+  - https://github.com/Shopify/flash-list/pull/149
+
+## [0.2.1] - 2022-03-09
+
+- Bug fix for style and last separator
+  - https://github.com/Shopify/flash-list/pull/141
 
 ## [0.2.0] - 2022-03-08
 


### PR DESCRIPTION
## Description

I have noticed we are missing a bunch of released versions in the `CHANGELOG`. @naqvitalha, don't forget to update it. I understand we don't have automated checks, yet, so we need to be diligent about updating it.

I have also noticed @naqvitalha you have merged a bunch of PRs such as https://github.com/Shopify/flash-list/pull/150 without adding anyone as a reviewer. I understand you needed to make those changes quickly but having someone to look at the code even after it was merged is still a good idea.

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
