### PR TITLE
Use ARM architecture for macos container in CI

### DIFF
--- a/.shopify-build/shared/containers.yml
+++ b/.shopify-build/shared/containers.yml
@@ -7,7 +7,9 @@ containers:
     docker_pull_timeout: 480
 
   macos:
-    anka: macos-xcode13
+    anka:
+      image: macos-xclt-xcode-ios
+      arch: arm
 
   docs_container:
     docker: gcr.io/shopify-docker-images/apps/production/apidocs-generator-alpine:production


### PR DESCRIPTION
Update the macos container to use the M1 hosts in CI and the new ARM compatible images