### PR TITLE
Pass getStableId as null if keyExtractor does not initially exist

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -224,26 +224,25 @@ class FlashList<T> extends React.PureComponent<
   private static getInitialMutableState<T>(
     flashList: FlashList<T>
   ): FlashListState<T> {
+    let getStableId: ((index: number) => string) | undefined;
+    if (
+      flashList.props.keyExtractor !== null &&
+      flashList.props.keyExtractor !== undefined
+    ) {
+      getStableId = (index) =>
+        // We assume `keyExtractor` function will never change from being `null | undefined` to defined and vice versa.
+        // Similarly, data should never be `null | undefined` when `getStableId` is called.
+        flashList.props.keyExtractor!(
+          flashList.props.data![index],
+          index
+        ).toString();
+    }
     return {
       data: null,
       layoutProvider: null!!,
-      dataProvider: new DataProvider(
-        (r1, r2) => {
-          return r1 !== r2;
-        },
-        (index) => {
-          if (
-            flashList.props == null ||
-            flashList.props.data == null ||
-            flashList.props.keyExtractor == null
-          ) {
-            return index.toString();
-          }
-          return flashList.props
-            .keyExtractor(flashList.props.data[index], index)
-            .toString();
-        }
-      ),
+      dataProvider: new DataProvider((r1, r2) => {
+        return r1 !== r2;
+      }, getStableId),
       numColumns: 0,
     };
   }


### PR DESCRIPTION
## Description

This fixes an issue raised in [this](https://github.com/Shopify/flash-list/pull/183#discussion_r831537767) comment - we should not pass a default `getStableId` method that relies on indices when `keyExtractor` is not defined when initial state is constructed.

Doing so will break some assumptions in `recyclerlistview` and how this method is used.

We have thought about going around this but users are never supposed to change `keyExtractor` to `null` and vice versa - if they do, they will get an exception (as they should never do so)

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
