### PR TITLE
Refactor tests to use find instead of findAll

### DIFF
--- a/src/__tests__/FlashList.test.tsx
+++ b/src/__tests__/FlashList.test.tsx
@@ -30,7 +30,7 @@ describe("FlashList", () => {
         estimatedFirstItemOffset={props?.estimatedFirstItemOffset}
       />
     );
-    flashList.findAll(ScrollView)[0].trigger("onLayout", {
+    flashList.find(ScrollView)?.trigger("onLayout", {
       nativeEvent: { layout: { height: 900, width: 400 } },
     });
     return flashList;
@@ -104,12 +104,9 @@ describe("FlashList", () => {
   });
   it("only forwards onBlankArea prop to AutoLayout when needed", () => {
     const flashList = mountFlashList();
-    expect(
-      flashList.findAll(AutoLayoutView)[0].instance.props.onBlankAreaEvent
-    ).toBeUndefined();
+    const autoLayoutView = flashList.find(AutoLayoutView)?.instance;
+    expect(autoLayoutView.props.onBlankAreaEvent).toBeUndefined();
     flashList.setProps({ onBlankArea: () => {} });
-    expect(
-      flashList.findAll(AutoLayoutView)[0].instance.props.onBlankAreaEvent
-    ).not.toBeUndefined();
+    expect(autoLayoutView.props.onBlankAreaEvent).not.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

Just a quick refactor to use `find` instead of `findAll`

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
