### PR TITLE
Add overrideItemType to contacts list

### DIFF
--- a/fixture/src/contacts/Contacts.tsx
+++ b/fixture/src/contacts/Contacts.tsx
@@ -44,6 +44,9 @@ const Contacts = () => {
           return <ContactCell contact={item as Contact} />;
         }
       }}
+      overrideItemType={(item) => {
+        return typeof item === "string" ? "sectionHeader" : "row";
+      }}
       ItemSeparatorComponent={ContactDivider}
       stickyHeaderIndices={stickyHeaderIndices}
       ListHeaderComponent={ContactHeader}


### PR DESCRIPTION
## Description
`<ContactSectionHeader/>` sometimes gets used to render `<ContactCell/>` during recycling. This is because we are not telling RLV that they're of different types. I've made a small fix to enable that. Nothing unmounts in this sample anymore :)