### PR TITLE
 Change `overrideItemType` prop name to `getItemType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Define `FlashList` props previously inherited from `VirtualizedList` and `FlatList` explicitly
   - https://github.com/Shopify/flash-list/pull/386
+- Change `overrideItemType` prop name to `getItemType`
+  - https://github.com/Shopify/flash-list/pull/369
 
 ## [0.5.0] - 2022-04-29
 

--- a/documentation/docs/fundamentals/performance-troubleshooting.md
+++ b/documentation/docs/fundamentals/performance-troubleshooting.md
@@ -24,6 +24,6 @@ If the numbers indicate that the performance is not good enough, you should act.
 
 ### Tips:
 
-1. To make your list more performant, ensure [`estimatedItemSize`](/usage#estimateditemsize) is as close as possible to the real median value. And if you have different types of items, you can improve recycling by using the [`overrideItemType`](/usage#overrideitemtype) prop.
+1. To make your list more performant, ensure [`estimatedItemSize`](/usage#estimateditemsize) is as close as possible to the real median value. And if you have different types of items, you can improve recycling by using the [`getItemType`](/usage#getitemtype) prop.
 
 2. Make sure your cell components don't have a `key` prop. Using this prop will lead to `FlashList` not being able to recycle views, losing all the benefits of using it over `FlatList`.

--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -315,17 +315,17 @@ onRefresh?: () => void;
 
 If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the `refreshing` prop correctly.
 
-### `overrideItemType`
+### `getItemType`
 
 ```ts
-overrideItemType?: (
+getItemType?: (
     item: T,
     index: number,
     extraData?: any
 ) => string | number | undefined;
 ```
 
-Allows developers to override type of items. This will improve recycling if you have different types of items in the list. Right type will be used for the right item.Default type is 0. If you don't want to change for an indexes just return undefined.
+Allows developers to specify item types. This will improve recycling if you have different types of items in the list. Right type will be used for the right item.Default type is 0. If you don't want to change for an indexes just return undefined.
 
 :::warning Performance
 This method is called very frequently. Keep it fast.

--- a/documentation/docs/guides/section-list.md
+++ b/documentation/docs/guides/section-list.md
@@ -94,7 +94,7 @@ const ContactsFlashList = () => {
           return <Text>{item.firstName}</Text>;
         }
       }}
-      overrideItemType={(item) => {
+      getItemType={(item) => {
         // To achieve better performance, specify the type based on the item
         return typeof item === "string" ? "sectionHeader" : "row";
       }}
@@ -164,7 +164,7 @@ const ContactsFlashList = () => {
         }
       }}
       stickyHeaderIndices={stickyHeaderIndices}
-      overrideItemType={(item) => {
+      getItemType={(item) => {
         // To achieve better performance, specify the type based on the item
         return typeof item === "string" ? "sectionHeader" : "row";
       }}

--- a/fixture/src/Messages/Messages.tsx
+++ b/fixture/src/Messages/Messages.tsx
@@ -42,7 +42,7 @@ const Messages = () => {
               break;
           }
         }}
-        overrideItemType={(item) => {
+        getItemType={(item) => {
           return item.type;
         }}
         data={messages}

--- a/fixture/src/contacts/Contacts.tsx
+++ b/fixture/src/contacts/Contacts.tsx
@@ -44,7 +44,7 @@ const Contacts = () => {
           return <ContactCell contact={item as Contact} />;
         }
       }}
-      overrideItemType={(item) => {
+      getItemType={(item) => {
         return typeof item === "string" ? "sectionHeader" : "row";
       }}
       ItemSeparatorComponent={ContactDivider}

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -185,7 +185,7 @@ class FlashList<T> extends React.PureComponent<
       numColumns,
       (index, props) => {
         // type of the item for given index
-        const type = props.overrideItemType?.(
+        const type = props.getItemType?.(
           props.data!![index],
           index,
           props.extraData

--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -221,7 +221,7 @@ export interface FlashListProps<TItem> extends ScrollViewProps {
    * If you don't want to change for an indexes just return undefined.
    * Performance: This method is called very frequently. Keep it fast.
    */
-  overrideItemType?: (
+  getItemType?: (
     item: TItem,
     index: number,
     extraData?: any

--- a/website/_includes/snippet2.js
+++ b/website/_includes/snippet2.js
@@ -2,7 +2,7 @@
   renderItem={({ item }) => {
     <TweetCell item={item} />;
   }}
-  overrideItemType={({ item }) => {
+  getItemType={({ item }) => {
     item.type;
   }}
   data={tweets}


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/flash-list/issues/368

As described in the attached issue, we are removing `override` prefix from `overrideItemType` and `overrideItemType`.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
