### PR TITLE
Add docs for SectionList

### DIFF
--- a/documentation/docs/guides/section-list.md
+++ b/documentation/docs/guides/section-list.md
@@ -11,7 +11,7 @@ React Native has a convenience component on top of `FlatList`, called [`SectionL
 - [`SectionSeparatorComponent`](https://reactnative.dev/docs/sectionlist#sectionseparatorcomponent)
 - [`stickySectionHeadersEnabled`](https://reactnative.dev/docs/sectionlist#stickysectionheadersenabled)
 
-`FlashList` offers none of these props but all of them are replaceable with existing props.
+**`FlashList` offers none of these props but all of them are replaceable with existing props.**
 
 The difficulty of migrating from `SectionList` to `FlashList` will depend on the data you have at hand - the data may be more suitable for `SectionList`, requiring you to massage the data, but the opposite can be true as well. In that case, using `FlashList` instead of `SectionList` might even result in less code.
 


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/flash-list/issues/377

As long as we don't support `SectionList`, we should provide users with docs explaining how to migrate from `SectionList` to `FlashList`.

## Reviewers’ hat-rack :tophat:

- Read the docs 🙂 
