### PR TITLE
fixed benchmark's multiple effect triggers

### DIFF
--- a/src/benchmark/useBenchmark.ts
+++ b/src/benchmark/useBenchmark.ts
@@ -86,7 +86,8 @@ export function useBenchmark(
       clearTimeout(cancelTimeout);
       cancellable.cancel();
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return [blankAreaTracker];
 }
 

--- a/src/benchmark/useFlatListBenchmark.ts
+++ b/src/benchmark/useFlatListBenchmark.ts
@@ -58,7 +58,8 @@ export function useFlatListBenchmark(
       clearTimeout(cancelTimeout);
       cancellable.cancel();
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return [];
 }
 


### PR DESCRIPTION
The benchmark needs to be canceled on unmount. The dependency array was not being passed to useEffect causing it to trigger many times in real world use cases. Explicitly passing empty array to make sure cleanup happens only on unmount.
