### PR TITLE
Restored dev.yml and changed CONTRIBUTING.md accordingly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,9 @@ We want this community to be **friendly and respectful** to each other. Please f
 
 ## Development workflow
 
-To get started with the project, run `dev up` and `yarn up` in the root directory to install the required dependencies for `flash-list` and our fixture app:
-
-`dev up` is necessary to be able to install Shopify's private dependencies and `yarn up` takes care of the rest.
+To get started with the project, run `yarn up` in the root directory to install the required dependencies for `flash-list` and our fixture app:
 
 ```sh
-dev up
 yarn up
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "up": "yarn && bundle install && cd fixture && yarn && cd ios && bundle exec pod install && brew tap wix/brew && brew install applesimutils && cd ../../ && yarn build",
+    "up": "/opt/dev/bin/dev up && bundle install && cd fixture && yarn && cd ios && bundle exec pod install && brew tap wix/brew && brew install applesimutils && cd ../../ && yarn build",
     "start": "cd fixture && react-native start",
     "test": "jest",
     "lint": "yarn eslint . --ext .ts,.tsx",


### PR DESCRIPTION
## Description

`dev.yml` file was removed by mistake, and it is needed to set up the project. Some dependencies are private and in order to be able to install them you will need to run `dev up` before you run `yarn up`.

I updated the `CONTRIBUTING.md` documentation so it is clear there as well.