### PR TITLE
chore: add Dependabot automerge workflow and update dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Europe/Berlin
     open-pull-requests-limit: 100
     insecure-external-code-execution: allow
     registries: "*"
@@ -26,12 +29,18 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Europe/Berlin
     open-pull-requests-limit: 100
     registries: "*"
   - package-ecosystem: bundler
     directory: "/fixture"
     schedule:
       interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Europe/Berlin
     open-pull-requests-limit: 100
     insecure-external-code-execution: allow
     registries: "*"
@@ -39,5 +48,8 @@ updates:
     directory: "/fixture"
     schedule:
       interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Europe/Berlin
     open-pull-requests-limit: 100
     registries: "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,65 @@
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: self-hosted
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major' &&
+          ((startsWith(steps.metadata.outputs.dependency-names, 'react-native') == true &&
+          endsWith(steps.metadata.outputs.dependency-names, 'react-native') == true) != true)
+        uses: actions/github-script@v6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const getPullRequestIdQuery = `query GetPullRequestId($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pullRequestNumber) {
+                  id
+                }
+              }
+            }`
+            const repoInfo = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pullRequestNumber: context.issue.number,
+            }
+            const response = await github.graphql(getPullRequestIdQuery, repoInfo)
+            await github.rest.pulls.createReview({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: 'APPROVE',
+            })
+            const enableAutoMergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+              enablePullRequestAutoMerge(input: {
+                pullRequestId: $pullRequestId,
+                mergeMethod: $mergeMethod
+              }) {
+                pullRequest {
+                  autoMergeRequest {
+                    enabledAt
+                    enabledBy {
+                      login
+                    }
+                  }
+                }
+              }
+            }`
+            const data = {
+              pullRequestId: response.repository.pullRequest.id,
+              mergeMethod: 'SQUASH',
+            }
+            await github.graphql(enableAutoMergeQuery, data)


### PR DESCRIPTION
## Description


Dependabot takes a lot of developers' time to merge and smoke test PRs. As one step automating this process, this PR [enables auto-merging dependabots](https://vault.shopify.io/pages/15549-Dependabot-Automerge) that are patched or minor version updates and pass all GitHub automated checks as well as add End-to-End testing in addition to our unit testing.

This PR includes Github workflow to auto merge dependabot's PRs that patched or minor version updates, excluding React Native dependency

### Reviewers’ hat-rack :tophat:

The flow can be tested only on main, so green CI should be enough for the PR to get merged. 

## Checklist

<!--- Please, make sure that when doing "Squash and rebase" or "Rebase and merge", the commit adheres to [conventional commits](https://github.com/Shopify/react-native-packages/blob/main/.github/CONTRIBUTING.md#conventional-commits) guideline -->

- [ ] I have added a decision record entry, PR includes changes to monorepo setup that may require explanation
