### PR TITLE
Add bot for CLA check

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,2 @@
+enabled:
+  - cla


### PR DESCRIPTION
Signing the CLA is necessary for external contributors.