### PR TITLE
Move to the public version of @shopify/react-native-performance-lists-profiler package

### DIFF
--- a/fixture/package.json
+++ b/fixture/package.json
@@ -17,7 +17,7 @@
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/stack": "^6.2.1",
     "@shopify/flash-list": "link:../",
-    "@shopify/react-native-performance-lists-profiler": "^0.0.12",
+    "@shopify/react-native-performance-lists-profiler": "^1.1.0",
     "react": "17.0.2",
     "react-native": "0.68.1",
     "react-native-fast-image": "^8.5.11",
@@ -28,21 +28,21 @@
     "react-native-screens": "^3.13.1"
   },
   "devDependencies": {
+    "@types/jest": "^27.5.0",
+    "@types/pixelmatch": "^5.2.4",
+    "@types/pngjs": "^6.0.1",
     "babel-jest": "^27.5.1",
     "babel-plugin-module-resolver": "^4.1.0",
+    "detox": "^19.7.1",
     "glob": "^8.0.3",
     "jest": "^27.5.1",
     "metro-config": "^0.71.0",
     "metro-react-native-babel-preset": "^0.71.1",
     "patch-package": "^6.4.7",
-    "postinstall-postinstall": "^2.1.0",
-    "typescript": "^4.7.4",
-    "@types/pixelmatch": "^5.2.4",
-    "@types/pngjs": "^6.0.1",
-    "detox": "^19.7.1",
     "pixelmatch": "^5.3.0",
     "pngjs": "^6.0.0",
-    "@types/jest": "^27.5.0"
+    "postinstall-postinstall": "^2.1.0",
+    "typescript": "^4.7.4"
   },
   "jest": {
     "preset": "react-native"

--- a/fixture/yarn.lock
+++ b/fixture/yarn.lock
@@ -1346,14 +1346,13 @@
     warn-once "^0.1.0"
 
 "@shopify/flash-list@link:..":
-  version "1.0.0"
-  dependencies:
-    recyclerlistview "3.3.0-beta.2"
+  version "0.0.0"
+  uid ""
 
-"@shopify/react-native-performance-lists-profiler@^0.0.12":
-  version "0.0.12"
-  resolved "https://npm.shopify.io/node/@shopify/react-native-performance-lists-profiler/-/0.0.12/react-native-performance-lists-profiler-0.0.12.tgz#394846142fd3e44cc4ddecf4a53911383a586624"
-  integrity sha512-WySQB3uYUXL1iJ7M5COyg7bnsbo/CFMf6wQ9TtcWyW6FvpwdVbUQ9HXFtA/Kb5HW9+yvsDq5LD/Fau7zeqFsfQ==
+"@shopify/react-native-performance-lists-profiler@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@shopify/react-native-performance-lists-profiler/-/react-native-performance-lists-profiler-1.1.0.tgz#298d899ac43f83d38356b15c16c6ba109fd6924e"
+  integrity sha512-Jj+9gMQxMqlO4dZFS9HDb8/aI8VraJL67aDrJpV2qWzWr7HUXah96qav3X7+jS0f6YvUDVzpe0cjy6WsVdo3+g==
 
 "@sideway/address@^4.1.3":
   version "4.1.3"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "up": "/opt/dev/bin/dev up && bundle install && yarn fixture-up && yarn e2e-up && yarn build && yarn fixture-web-up",
+    "up": "bundle install && yarn fixture-up && yarn e2e-up && yarn build && yarn fixture-web-up",
     "fixture-web-up": "cd fixture/web-app && yarn && cd ../../",
     "fixture-up": "cd fixture && yarn && cd ios && bundle exec pod install && cd ../../",
     "e2e-up": "cd fixture/ios && brew tap wix/brew && brew install applesimutils && cd ../../",


### PR DESCRIPTION


## Description

We have released `@shopify/react-native-performance-lists-profiler` publicly with the `FlashList` profiling tools, so that we no longer have to run `dev up` which was available to Shopify employees only. 
