### PR TITLE
Fix broken links

### DIFF
--- a/documentation/docs/fundamentals/performance-troubleshooting.md
+++ b/documentation/docs/fundamentals/performance-troubleshooting.md
@@ -20,4 +20,4 @@ The following metrics can be used for profiling the list's overall performance:
 
 ## How to improve performance
 
-If the numbers indicate that the performance is not good enough, you should act - **continue [here](./performant-components) to learn more about how to optimize your list.**
+If the numbers indicate that the performance is not good enough, you should act - **continue [here](/fundamentals/performant-components) to learn more about how to optimize your list.**

--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -378,7 +378,7 @@ getItemType?: (
 ) => string | number | undefined;
 ```
 
-Allows developers to specify item types. This will improve recycling if you have different types of items in the list. Right type will be used for the right item.Default type is 0. If you don't want to change for an indexes just return undefined. You can see example of how to use this prop [here](/guides/performant-components#getitemtype).
+Allows developers to specify item types. This will improve recycling if you have different types of items in the list. Right type will be used for the right item.Default type is 0. If you don't want to change for an indexes just return undefined. You can see example of how to use this prop [here](/fundamentals/performant-components#getitemtype).
 
 :::warning Performance
 This method is called very frequently. Keep it fast.


### PR DESCRIPTION
## Description

Fix a couple of broken links in the documentation.

I will update [this](https://github.com/Shopify/flash-list/pull/383) PR to also run `yarn build` in the `documentation` directory, so the CI checks possibly broken links in the future.
