### PR TITLE
Fix og image meta tag

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -20,7 +20,7 @@ appname: FlashList
         href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡️</text></svg>">
         <meta property="og:title" content="FlashList - super fast list for react native" />
         <meta property="og:description" content="FlashList is a faster alternative to FlatList with a similar API. Migrate in a few seconds and get major performance boost." />
-        <meta property="og:image" content="./img/social-share.png" />
+        <meta property="og:image" content="/img/social-share.png" />
     </head>
 
 <body>


### PR DESCRIPTION
## Description

Fixing og image tag. Tested with https://www.opengraph.xyz/ and [ngrok](https://github.com/bubenshchykov/ngrok) - you can serve the local website, forward `ngrok` to it, get a public URL from the `ngrok` command and supply that to opengraph.

These are the previews that you will see on the various social platforms:

<img width="456" alt="image" src="https://user-images.githubusercontent.com/9371695/176471916-364a0ee6-de06-441f-9d2c-fff7416f9836.png">

<img width="436" alt="image" src="https://user-images.githubusercontent.com/9371695/176472110-892c9bfb-8ff5-4c5d-835b-b77b3c15cc74.png">


![image](https://user-images.githubusercontent.com/9371695/176471977-284392e5-6616-432f-95ce-e373df615d09.png)
