### PR TITLE
Change 2x performance to instant performance

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -53,10 +53,10 @@ appname: FlashList
             {% highlight tsx %}{% include snippet1.js %} {% endhighlight %}
             <div class="info">
                 <h1>
-                    Same props.<br />Instant performance.
+                    Similar props.<br />Instant performance.
                 </h1>
                 <p>
-                    Even with the same props as the React Native FlatList, {{page.appname}} recycles components
+                    Even with the similar props as the React Native FlatList, {{page.appname}} recycles components
                     under the hood
                     to maximize performance.
                 </p>


### PR DESCRIPTION
## Description

Performance is hard to quantify and the claim of `2x performance` does not have a basis in real metrics. I am changing it to `Instant performance` instead:

![image](https://user-images.githubusercontent.com/9371695/176477050-b99bd237-ae1b-459d-9ef8-db8a49f46ad1.png)
