### PR TITLE
Change publishConfig to be public

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "react-native"
   ],
   "publishConfig": {
-    "access": "restricted"
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org/"
   },
   "description": "FlashList is a more performant FlatList replacement",
   "author": "shopify",


### PR DESCRIPTION
## Description

Prepare `flash-list` to be open-sourced by changing the publish access to `public`.
