### PR TITLE
Add kotlin-gradle-plugin to buildscript in project build.gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Add kotlin-gradle-plugin to buildscript in project build.gradle
+  - https://github.com/Shopify/flash-list/pull/481
+
 ## [1.0.2] - 2022-06-30
 
 - Minor changes

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Swap from FlatList in seconds. Get instant performance.
 
 Add the package to your project via `yarn add @shopify/flash-list` and run `pod install` in the `ios` directory.
 
-If you get the error `Plugin with id 'kotlin-android' not found` while building on Android, go to `android/build.gradle` and add `classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0")` inside your `dependencies` block. Please change the plugin version as per your needs.
-
 ## Usage
 
 We recommend reading the detailed documentation for using `FlashList` [here](https://shopify.github.io/flash-list/docs/usage).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ def _androidTestRunnerVersion = _ext.has('androidTestRunnerVersion') ? _ext.andr
 
 buildscript {
     // buildscript is evaluated before any other task is executed, so this must be defined here
-    ext._kotlinVersion = (ext.has("kotlinVersion")) ?  ext.kotlinVersion() : "1.5.30"
+    ext._kotlinVersion = rootProject.ext.has("kotlinVersion") ?  rootProject.ext.kotlinVersion() : '1.5.30'
 
     repositories {
         mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,10 +9,22 @@ def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion 
 def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '30.0.2'
 def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 21
 def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 30
-def _kotlinVersion = _ext.has('kotlinVersion') ? _ext.kotlinVersion : '1.5.30'
 def _junitVersion = _ext.has('junitVersion') ? _ext.junitVersion : '4.13.2'
 def _mockitoVersion = _ext.has('mockitoVersion') ? _ext.mockitoVersion : '3.2.0'
 def _androidTestRunnerVersion = _ext.has('androidTestRunnerVersion') ? _ext.androidTestRunnerVersion : '1.1.0'
+
+buildscript {
+    // buildscript is evaluated before any other task is executed, so this must be defined here
+    ext._kotlinVersion = (ext.has("kotlinVersion")) ?  ext.kotlinVersion() : "1.5.30"
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${_kotlinVersion}")
+    }
+}
 
 android {
     compileSdkVersion _compileSdkVersion


### PR DESCRIPTION
## Description

Fixes the error many developers will encounter when using this library in their project, which is explained in the README:

> If you get the error `Plugin with id 'kotlin-android' not found` while building on Android, go to `android/build.gradle` and add `classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0")` inside your `dependencies` block. Please change the plugin version as per your needs.

This PR also removes the above paragraph from the README as it's no longer needed.

It does this by adding the dependency in the buildscript in the project build.gradle. We use a similar approach in Expo modules, for example in [expo-gl](https://github.com/expo/expo/blob/98e3d1132335b3a16bdd954103618e9f06ec2e49/packages/expo-gl/android/build.gradle#L8-L36), and you will find [the same pattern in other libraries too](https://github.com/mrousavy/react-native-blurhash/blob/d72de0e175783d5e540e1e2e689c9584159039a0/android/build.gradle#L1-L15).

## Reviewers’ hat-rack :tophat:

I don't think this applies to tophatting as there is no change to runtime behavior. Here's how you can reproduce the issue and test the fix:

```
npx react-native init myapp
cd myapp
yarn add @shopify/flash-list
yarn android # notice the build will fail with the error mentioned above
# now copy the diff from this pr over to node_modules/@shopify/flash-list/android/build.gradle
yarn android # notice the build will succeed
```

## Screenshots or videos (if needed)

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/90494/176788036-32ad4edf-f76c-4360-8d4f-5d7300289ee5.png">

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
