### PR TITLE
Run CI checks actions on a PR

### DIFF
--- a/.github/workflows/flash-list.yml
+++ b/.github/workflows/flash-list.yml
@@ -1,6 +1,10 @@
 name: flash-list
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 env:
   RUBY_VERSION: 3.0.3

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,10 @@
 name: website
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 env:
   RUBY_VERSION: 3.0.3


### PR DESCRIPTION
## Description

Currently, most of GitHub workflows are not run on a PR. Let's change the `on` conditions to fix this.
