### PR TITLE
Migrate auto merge action to the GitHub runner

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Description

Migrate auto merge action to the GitHub runner, as `self-hosted` runners are not available for open-source repos.
