### PR TITLE
Fix missing return for `getItemType` in website snippet example

### DIFF
--- a/website/_includes/snippet2.js
+++ b/website/_includes/snippet2.js
@@ -3,7 +3,7 @@
     <TweetCell item={item} />;
   }}
   getItemType={({ item }) => {
-    item.type;
+    return item.type;
   }}
   data={tweets}
 />;


### PR DESCRIPTION
## Description

Function signature shows that it can return a string, number, or undefined. It seems like the intention in this snippet is to return `item.type` so that it can be properly recycled.

## Reviewers’ hat-rack :tophat:

N/A

## Screenshots or videos (if needed)

N/A

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
(Not applicable?)