### PR TITLE
Remove buildkite require from shipit yml

### DIFF
--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -1,7 +1,3 @@
-ci:
-  require:
-    - buildkite/flash-list
-
 dependencies:
   override:
     - yarn install


### PR DESCRIPTION
## Description

Currently, all PRs are stuck because they wait for the buildkite step which no longer runs. Let's remove it!