### PR TITLE
Fix typo in web example snippets

### DIFF
--- a/website/_includes/snippet1.js
+++ b/website/_includes/snippet1.js
@@ -1,6 +1,6 @@
 <FlashList
   renderItem={({ item }) => {
-    <TweetCell item={item} />;
+    return <TweetCell item={item} />;
   }}
   estimatedItemSize={50}
   data={tweets}

--- a/website/_includes/snippet2.js
+++ b/website/_includes/snippet2.js
@@ -1,6 +1,6 @@
 <FlashList
   renderItem={({ item }) => {
-    <TweetCell item={item} />;
+    return <TweetCell item={item} />;
   }}
   getItemType={({ item }) => {
     return item.type;


### PR DESCRIPTION
Adds the missing "return" keyword to the `renderItem` examples on the front page. Alternatively, could change the curly braces to rounded brackets:

```tsx
<FlashList
  renderItem={({ item }) => (
    <TweetCell item={item} />
  )}
  estimatedItemSize={50}
  data={tweets}
/>;
```