### PR TITLE
Clarify Expo installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Clarify installation instructions in Expo projects
+  - https://github.com/Shopify/flash-list/pull/497
+
 ## [1.0.3] - 2022-07-01
 
 - Add kotlin-gradle-plugin to buildscript in project build.gradle

--- a/documentation/docs/index.mdx
+++ b/documentation/docs/index.mdx
@@ -36,17 +36,14 @@ feature, you will need to manually link the dependency - read
 </TabItem>
 <TabItem value="expo">
 
+- ✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
+- ❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
+
 ```bash
 expo install @shopify/flash-list expo-dev-client
 ```
 
-You can then run the app on iOS or Android via:
-
-```bash
-expo run:ios
-# or
-expo run:android
-```
+You can then [create a new Development Build](https://docs.expo.dev/development/build/) and begin using `FlashList`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Description

The instructions added in https://github.com/Shopify/flash-list/commit/34019f5999d1e876a1c1d6942e253d5293cd36ad are good, I just wanted to add a bit more context and clarity to it.

- I removed the `expo run:ios` and `expo run:android` part and instead linked to the canonical page to teach developers about creating development builds: https://docs.expo.dev/development/build/ - this lists the `run` commands as one option.
- I added our standard messaging as outlined in [this doc](https://www.notion.so/expo/Documenting-Expo-support-in-READMEs-f250a20b4bd5472cab0757918cb21062) to make it clear that this requires development builds and does not (yet) work in Expo Go. (We can probably update this after SDK 46 is release 😄 )

## Reviewers’ hat-rack :tophat:

n/a

## Screenshots or videos (if needed)

<img width="1650" alt="image" src="https://user-images.githubusercontent.com/90494/176949918-85f07215-3a7b-4a21-91fa-627b463d374d.png">

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
