### PR TITLE
Allow providing an external scrollview.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [1.0.4] - 2022-07-02
 
 - Build fix for Android projects having `kotlinVersion` defined in `build.gradle`.
+- Allow providing an external scrollview.
 
 ## [1.0.3] - 2022-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Build fix for Android projects having `kotlinVersion` defined in `build.gradle`.
 - Allow providing an external scrollview.
+  - https://github.com/Shopify/flash-list/pull/502
 
 ## [1.0.3] - 2022-07-01
 

--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -96,12 +96,12 @@ estimatedItemSize?: number;
 
 ---
 
-### `ExternalScrollViewComponent`
+### `renderScrollComponent`
 
 Rendered as the main scrollview. Its contract for the scroll event should match the native scroll event contract, i.e. `scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }`
 
 ```ts
-return <FlashList ExternalScrollViewComponent={Animated.ScrollView} />;
+return <FlashList renderScrollComponent={Animated.ScrollView} />;
 ```
 
 ### `CellRendererComponent`

--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -96,6 +96,14 @@ estimatedItemSize?: number;
 
 ---
 
+### `ExternalScrollViewComponent`
+
+Rendered as the main scrollview. Its contract for the scroll event should match the native scroll event contract, i.e. `scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }`
+
+```ts
+return <FlashList ExternalScrollViewComponent={Animated.ScrollView} />;
+```
+
 ### `CellRendererComponent`
 
 Each cell is rendered using this element. Can be a React Component Class, or a render function. The root component should always be a `CellContainer` which is also the default component used. Ensure that the original `props` are passed to the returned `CellContainer`. The `props` contain the following properties:

--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -96,14 +96,6 @@ estimatedItemSize?: number;
 
 ---
 
-### `renderScrollComponent`
-
-Rendered as the main scrollview. Its contract for the scroll event should match the native scroll event contract, i.e. `scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }`
-
-```ts
-return <FlashList renderScrollComponent={Animated.ScrollView} />;
-```
-
 ### `CellRendererComponent`
 
 Each cell is rendered using this element. Can be a React Component Class, or a render function. The root component should always be a `CellContainer` which is also the default component used. Ensure that the original `props` are passed to the returned `CellContainer`. The `props` contain the following properties:
@@ -455,6 +447,18 @@ refreshing?: boolean;
 ```
 
 Set this true while waiting for new data from a refresh.
+
+### `renderScrollComponent`
+
+```tsx
+import type { ScrollViewProps } from "react-native";
+
+renderScrollComponent?:
+    | React.ComponentType<ScrollViewProps>
+    | React.FC<ScrollViewProps>;
+```
+
+Rendered as the main scrollview.
 
 ### `viewabilityConfig`
 

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -350,6 +350,7 @@ class FlashList<T> extends React.PureComponent<
           windowCorrectionConfig={this.getUpdatedWindowCorrectionConfig()}
           itemAnimator={this.itemAnimator}
           suppressBoundedSizeException
+          externalScrollView={this.props.ExternalScrollViewComponent as any}
         />
       </StickyHeaderContainer>
     );

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -351,7 +351,9 @@ class FlashList<T> extends React.PureComponent<
           windowCorrectionConfig={this.getUpdatedWindowCorrectionConfig()}
           itemAnimator={this.itemAnimator}
           suppressBoundedSizeException
-          externalScrollView={renderScrollComponent as any}
+          externalScrollView={
+            renderScrollComponent as RecyclerListViewProps["externalScrollView"]
+          }
         />
       </StickyHeaderContainer>
     );

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -276,6 +276,7 @@ class FlashList<T> extends React.PureComponent<
       initialScrollIndex,
       style,
       contentContainerStyle,
+      renderScrollComponent,
       ...restProps
     } = this.props;
 
@@ -350,7 +351,7 @@ class FlashList<T> extends React.PureComponent<
           windowCorrectionConfig={this.getUpdatedWindowCorrectionConfig()}
           itemAnimator={this.itemAnimator}
           suppressBoundedSizeException
-          externalScrollView={this.props.ExternalScrollViewComponent as any}
+          externalScrollView={renderScrollComponent as any}
         />
       </StickyHeaderContainer>
     );

--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -7,7 +7,6 @@ import {
   ViewStyle,
   ColorValue,
 } from "react-native";
-import type { ScrollViewDefaultProps } from "recyclerlistview/dist/reactnative/core/scrollcomponent/BaseScrollView";
 
 import { BlankAreaEventHandler } from "./native/auto-layout/AutoLayoutView";
 import ViewToken from "./viewability/ViewToken";
@@ -125,12 +124,11 @@ export interface FlashListProps<TItem> extends ScrollViewProps {
   ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
 
   /**
-   * Rendered as the main scrollview. Its contract for the scroll event should match the native scroll event contract, i.e.
-   * `scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }`
+   * Rendered as the main scrollview.
    */
   renderScrollComponent?:
-    | React.ComponentType<ScrollViewDefaultProps>
-    | React.FC<ScrollViewDefaultProps>;
+    | React.ComponentType<ScrollViewProps>
+    | React.FC<ScrollViewProps>;
 
   /**
    * You can use `contentContainerStyle` to apply padding that will be applied to the whole content itself.

--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -128,7 +128,7 @@ export interface FlashListProps<TItem> extends ScrollViewProps {
    * Rendered as the main scrollview. Its contract for the scroll event should match the native scroll event contract, i.e.
    * `scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }`
    */
-  ExternalScrollViewComponent?:
+  renderScrollComponent?:
     | React.ComponentType<ScrollViewDefaultProps>
     | React.FC<ScrollViewDefaultProps>;
 

--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import {
   StyleProp,
   ScrollViewProps,
@@ -6,6 +7,7 @@ import {
   ViewStyle,
   ColorValue,
 } from "react-native";
+import type { ScrollViewDefaultProps } from "recyclerlistview/dist/reactnative/core/scrollcomponent/BaseScrollView";
 
 import { BlankAreaEventHandler } from "./native/auto-layout/AutoLayoutView";
 import ViewToken from "./viewability/ViewToken";
@@ -121,6 +123,14 @@ export interface FlashListProps<TItem> extends ScrollViewProps {
    * Styling for internal View for `ListHeaderComponent`.
    */
   ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
+
+  /**
+   * Rendered as the main scrollview. Its contract for the scroll event should match the native scroll event contract, i.e.
+   * `scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }`
+   */
+  ExternalScrollViewComponent?:
+    | React.ComponentType<ScrollViewDefaultProps>
+    | React.FC<ScrollViewDefaultProps>;
 
   /**
    * You can use `contentContainerStyle` to apply padding that will be applied to the whole content itself.


### PR DESCRIPTION
## Description

Fixes (issue #)

This PR will allow passing an external scrollview to the `recyclerlistview`, which is needed to allow gesture interactions with `react-native-gesture-handler` especially on **Android**.

## Reviewers’ hat-rack :tophat:

- Prop description and docs.

## Screenshots or videos (if needed)

#### Before 

https://user-images.githubusercontent.com/4061838/177045508-f5b21abc-7604-4292-9835-c8c26018afd4.mov

#### After 

https://user-images.githubusercontent.com/4061838/177045515-b311fcbd-c06b-43b0-9254-b0ca9be93620.mov
 
## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
