### PR TITLE
Add `tslib` as a dependency to fix #513

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - https://github.com/Shopify/flash-list/pull/497
 - Upgrade recyclerlistview to v4.0.1
   - https://github.com/Shopify/flash-list/pull/507
+- Add tslib as a dependency
+  - https://github.com/Shopify/flash-list/pull/514
 
 ## [1.0.4] - 2022-07-02
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
   ],
   "dependencies": {
     "recyclerlistview": "4.0.1",
-    "tslib": "2.1.0"
+    "tslib": "2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jestSetup.js"
   ],
   "dependencies": {
-    "recyclerlistview": "4.0.1"
+    "recyclerlistview": "4.0.1",
+    "tslib": "2.1.0"
   }
 }


### PR DESCRIPTION
## Description

Fixes #513 

Without adding `tslib` as a dependency, errors are thrown when using `onViewableItemsChanged`

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

N/A

## Checklist

- [X] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
