### PR TITLE
Update image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![FlashList Image](./FlashList.png)
+![FlashList Image](https://raw.githubusercontent.com/Shopify/flash-list/main/FlashList.png)
 
 <div align="center">
   <a href="https://shopify.github.io/flash-list/">Website</a> •


### PR DESCRIPTION
## Description

Update the README's image to reference a static URL.

This should fix the broken image on the NPM registry for future releases.

## Screenshots or videos (if needed)

This is what the NPM registry currently looks like:
<img width="754" alt="npm-flashlist" src="https://user-images.githubusercontent.com/49806985/177653849-def8f1ce-dba2-47ad-b347-760111df1f1f.png">

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
