### PR TITLE
fix: podspec double quotes around version string

### DIFF
--- a/RNFlashList.podspec
+++ b/RNFlashList.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license          = package['license']
   s.author           = package['author']
   s.platforms        = { :ios => '11.0', :tvos => '12.0' }
-  s.source           = { git: 'https://github.com/shopify/flash-list.git', tag: 'v#{s.version}' }
+  s.source           = { git: 'https://github.com/shopify/flash-list.git', tag: "v#{s.version}" }
   s.source_files     = 'ios/Sources/**/*'
   s.requires_arc     = true
   s.swift_version    = '5.0'


### PR DESCRIPTION
## Description

Fixes bug in podspec where version string won't be interpolated correctly.

