### PR TITLE
Fixed crash when `estimatedListSize`  is used in an empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fixed crash when `estimatedListSize` is used in an empty list
+  - https://github.com/Shopify/flash-list/pull/546
+
 ## [1.2.0] - 2022-07-18
 
 - Fixed out of bound read from data

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jestSetup.js"
   ],
   "dependencies": {
-    "recyclerlistview": "4.1.1",
+    "recyclerlistview": "4.1.2",
     "tslib": "2.4.0"
   }
 }


### PR DESCRIPTION
## Description

Fixes #543 

`ListEmptyComponent` breaks if used with `estimatedListSize`. The issue was a missing null check inside RLV. This PR addresses the issue.

## Reviewers’ hat-rack :tophat:

Without changes in this PR, any list trying to render `ListEmptyComponent` will break if used with `estimatedListSize`

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
