### PR TITLE
made first getDerivedStateFromProps param readonly

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -141,7 +141,7 @@ class FlashList<T> extends React.PureComponent<
 
   // Some of the state variables need to update when props change
   static getDerivedStateFromProps<T>(
-    nextProps: FlashListProps<T>,
+    nextProps: Readonly<FlashListProps<T>>,
     prevState: FlashListState<T>
   ): FlashListState<T> {
     const newState = { ...prevState };


### PR DESCRIPTION
## Description

Types of property 'getDerivedStateFromProps' are incompatible.

![image](https://user-images.githubusercontent.com/31435412/182809194-2b96a5f7-ca49-4e0b-ba86-e5100be25607.png)

The problem is in getDerivedStateFromProps first param type, react expects arg of type Readonly.

![image](https://user-images.githubusercontent.com/31435412/182810248-43d6065b-c9a1-4242-b6a6-56ddd2fc3c40.png)
![image](https://user-images.githubusercontent.com/31435412/182809702-e5571f55-48a4-4684-988d-ddc39d672905.png)

My solution is to wrap first arg with Readonly.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->
