### PR TITLE
docs: update unsupported list

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -612,7 +612,6 @@ The following props from `FlatList` are currently not implemented:
 - [`debug`](https://reactnative.dev/docs/virtualizedlist#debug)
 - [`listKey`](https://reactnative.dev/docs/virtualizedlist#listkey)
 - [`onScrollToIndexFailed`](https://reactnative.dev/docs/virtualizedlist#onscrolltoindexfailed)
-- [`renderScrollComponent`](https://reactnative.dev/docs/virtualizedlist#renderscrollcomponent)
 - [`windowSize`](https://reactnative.dev/docs/virtualizedlist#windowsize)
 
 Unsupported methods:


### PR DESCRIPTION


## Description

Fixes (issue #)

`renderScrollComponent` prop is supported in  [PR](https://github.com/Shopify/flash-list/pull/502), so remove it from the 'Unsupported' list.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ] check the docs.



## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
