### PR TITLE
Update index.mdx

### DIFF
--- a/documentation/docs/index.mdx
+++ b/documentation/docs/index.mdx
@@ -37,7 +37,7 @@ feature, you will need to manually link the dependency - read
 <TabItem value="expo">
 
 - ✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
-- ❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
+- ✅ This library can be used with "Expo Go" from SDK 46 upwards or with a development client [requires custom native code](https://docs.expo.dev/workflow/customizing/).
 
 ```bash
 expo install @shopify/flash-list expo-dev-client


### PR DESCRIPTION
## Description

Adding information that Expo Go is supported from SDK 46 upwards. 