### PR TITLE
Fix Prop types on AutoLayoutView to support children not being an intrinsic prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Fixes type checking error in `AutoLayoutView` due to `children` not being an explicit type
+  - https://github.com/Shopify/flash-list/pull/567
 
 ## [1.2.1] - 2022-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fixes type checking error in `AutoLayoutView` due to `children` not being an explicit type
+
 ## [1.2.1] - 2022-08-03
 
 - Fixed crash when `estimatedListSize` is used in an empty list

--- a/src/native/auto-layout/AutoLayoutView.tsx
+++ b/src/native/auto-layout/AutoLayoutView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, ReactNode } from "react";
 import { LayoutChangeEvent } from "react-native";
 
 import AutoLayoutViewNativeComponent from "./AutoLayoutViewNativeComponent";
@@ -25,6 +25,7 @@ export interface BlankAreaEvent {
 }
 
 export interface AutoLayoutViewProps {
+  children?: ReactNode;
   onBlankAreaEvent?: BlankAreaEventHandler;
   onLayout?: (event: LayoutChangeEvent) => void;
   disableAutoLayout?: boolean;

--- a/src/native/auto-layout/AutoLayoutViewNativeComponentProps.ts
+++ b/src/native/auto-layout/AutoLayoutViewNativeComponentProps.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from "react";
+
 export interface OnBlankAreaEvent {
   nativeEvent: {
     offsetStart: number;
@@ -8,6 +10,7 @@ export interface OnBlankAreaEvent {
 type OnBlankAreaEventHandler = (event: OnBlankAreaEvent) => void;
 
 export interface AutoLayoutViewNativeComponentProps {
+  children?: ReactNode;
   onBlankAreaEvent: OnBlankAreaEventHandler;
   enableInstrumentation: boolean;
   disableAutoLayout?: boolean;


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->
When attempting to type check `FlashList` in an Expo 46 environment, TypeScript throws a pair of errors in `AutoLayoutView` due to `children` not being a defined prop of itself nor `AutoLayoutViewNativeComponent`.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

Note: If you, like me, thought `"exclude": ["node_modules"]` would fix this, I recommend taking a look at the [tsconfig reference page](https://www.typescriptlang.org/tsconfig#exclude) so we can commiserate on what `exclude` actually means...

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

Current error:
<img width="1797" alt="Screen Shot 2022-08-16 at 3 53 35 PM" src="https://user-images.githubusercontent.com/6586509/184983188-d0a999e9-7f08-4a6c-abfd-877e1a1b9c4f.png">


## Checklist

- [X] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
