### PR TITLE
Solves the header remount when switching from an empty data array #575

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Fixes type checking error in `AutoLayoutView` due to `children` not being an explicit type
   - https://github.com/Shopify/flash-list/pull/567
+- Fixes the header re-mount when switching from an empty data array
+  - https://github.com/Shopify/flash-list/pull/576
 
 ## [1.2.1] - 2022-08-03
 

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -427,7 +427,7 @@ class FlashList<T> extends React.PureComponent<
     return (
       <>
         <PureComponentWrapper
-          enabled={children.length > 0 || this.isEmptyList}
+          enabled={true}
           contentStyle={this.props.contentContainerStyle}
           horizontal={this.props.horizontal}
           header={this.props.ListHeaderComponent}


### PR DESCRIPTION
## Description

Fixes #575

This PR solves the header unmount when switching from an empty data array.

But, being unfamiliar with the code of the package, I'm not sure if it can potentially introduce any regression.


## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
