### PR TITLE
Proper  react-native-performance-lists-profiler links

### DIFF
--- a/documentation/docs/fundamentals/performance-troubleshooting.md
+++ b/documentation/docs/fundamentals/performance-troubleshooting.md
@@ -14,8 +14,8 @@ FlashList can appear to be slower than FlatList in dev mode. The primary reason 
 
 The following metrics can be used for profiling the list's overall performance:
 
-- **blank area - a size of a visible blank area on scroll.** Use the built-in [`onBlankArea`](/usage#onBlankArea) event to get it reported. You can also use this event for tracking this metric in production. Alternatively, you can use [react-native-performance-lists-profiler](https://react-native-performance.docs.shopify.io/guides/react-native-performance-lists-profiler) package which also comes with a Flipper plugin.
-- **TTI - time-to-interactive of the list.** Comes along with blank area as part of [react-native-performance-lists-profiler](https://react-native-performance.docs.shopify.io/guides/react-native-performance-lists-profiler) package. This is a great option for local profiling - however, we do not recommend using it currently in production.
+- **blank area - a size of a visible blank area on scroll.** Use the built-in [`onBlankArea`](/usage#onBlankArea) event to get it reported. You can also use this event for tracking this metric in production. Alternatively, you can use [react-native-performance-lists-profiler](https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-lists-profiler/) package which also comes with a Flipper plugin.
+- **TTI - time-to-interactive of the list.** Comes along with blank area as part of [react-native-performance-lists-profiler](https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-lists-profiler/) package. This is a great option for local profiling - however, we do not recommend using it currently in production.
 - **FPS - frames per second.** For both native and JS FPS, you can either use the built-in performance monitor or we recommend [this](https://github.com/bamlab/react-native-performance) opensource plugin. Using native profilers in Xcode and Android Studio is a yet-another option but they track only the native FPS.
 
 ## How to improve performance


### PR DESCRIPTION
Don't know if it was intentional or not, original links were pointing to Okta, the new links are now pointing to https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-lists-profiler/

## Description

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
