### PR TITLE
Expose columnIndex to MasonryFlashList.renderItem via extraData.

### DIFF
--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -179,6 +179,10 @@ const MasonryFlashListComponent = React.forwardRef(
                     ...innerArgs,
                     item: innerArgs.item.originalItem,
                     index: innerArgs.item.originalIndex,
+                    extraData: {
+                      ...innerArgs.extraData,
+                      columnIndex: args.index,
+                    },
                   }) ?? null
                 );
               }}

--- a/src/__tests__/MasonryFlashList.test.ts
+++ b/src/__tests__/MasonryFlashList.test.ts
@@ -26,6 +26,32 @@ describe("MasonryFlashList", () => {
     });
     masonryFlashList.unmount();
   });
+  it("renders items and provides columnIndex as extraData", () => {
+    const mockRenderItem = jest.fn(({ extraData: { columnIndex } }) => null);
+    const masonryFlashList = mountMasonryFlashList({
+      renderItem: mockRenderItem,
+      data: ["One", "Two", "Three"],
+      numColumns: 3,
+    });
+    expect(mockRenderItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraData: { columnIndex: 0 },
+      })
+    );
+
+    expect(mockRenderItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraData: { columnIndex: 1 },
+      })
+    );
+
+    expect(mockRenderItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraData: { columnIndex: 2 },
+      })
+    );
+    masonryFlashList.unmount();
+  });
   it("raised onLoad event only when first internal child mounts", () => {
     const onLoadMock = jest.fn();
     const ref = React.createRef<MasonryFlashListRef<string>>();


### PR DESCRIPTION
## Description

Adds an implicit `columnIndex: number` to `extraData` when using `MasonryFlashList` in order to expose which column information to the presentation layer.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

