### PR TITLE
Fix typings for MasonryFlashListProps

### DIFF
--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -31,6 +31,7 @@ export interface MasonryFlashListProps<T>
     | "initialScrollIndex"
     | "inverted"
     | "onBlankArea"
+    | "renderItem"
     | "viewabilityConfigCallbackPairs"
   > {
   /**


### PR DESCRIPTION
## Description

Fixes Type Script issue:
```
node_modules/@shopify/flash-list/dist/MasonryFlashList.d.ts(10,18): error TS2430: Interface 'MasonryFlashListProps<T>' incorrectly extends interface 'Omit<FlashListProps<T>, "horizontal" | "inverted" | "initialScrollIndex" | "viewabilityConfigCallbackPairs" | "onBlankArea">'.
  Types of property 'renderItem' are incompatible.
    Type 'MasonryListRenderItem<T> | null | undefined' is not assignable to type 'ListRenderItem<T> | null | undefined'.
      Type 'MasonryListRenderItem<T>' is not assignable to type 'ListRenderItem<T>'.
        Types of parameters 'info' and 'info' are incompatible.
          Type 'ListRenderItemInfo<T>' is missing the following properties from type 'MasonryListRenderItemInfo<T>': columnSpan, columnIndex
```

Because `MasonryFlashList` and `FlashList` have different signature for `renderItem`, type script says they are incompatible and `MasonryFlashListProps` can't directly inherit it from `FlashListProps`. Easiest solution is to add `renderItem` to omitted props, so `MasonryFlashListProps` will have 'fresh' signature for this method.


<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Testing

Run type script static check on project (and possibly on some example project too). 
