### PR TITLE
Fix "Edit this page" link in documentation

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -78,7 +78,7 @@ module.exports = {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl:
-            "https://github.com/shopify/flash-list/edit/main/docusaurus/",
+            "https://github.com/Shopify/flash-list/blob/main/documentation",
         },
         blog: false,
         pages: false,


### PR DESCRIPTION
## Description

Fixes 404 when attempting to edit documentation page.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ] Start docs app locally and attempt to edit any page.

## Screenshots or videos (if needed)

![x](https://user-images.githubusercontent.com/719641/199673412-53f545e1-670a-4158-b18e-d5b1859a19bd.gif)

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
