### PR TITLE
Update known-issues.md

### DIFF
--- a/documentation/docs/known-issues.md
+++ b/documentation/docs/known-issues.md
@@ -38,4 +38,3 @@ FlashList will run in JS only mode on both Windows and macOS. We don't have plan
 
 When you scroll down a FlashList of components containing images, on iOS it will show the incorrect image and flicker to the correct image once the correct URI is loaded. To avoid this, you need to check if the URI ref of the current item rendering is the URI of the image you want to render. If it is not, then you need to render a blank image and then render the correct image once the URI is loaded. An example
 of this is shown on this [gist here](https://gist.githubusercontent.com/naqvitalha/f13772b7bc5d361fb95cdd008f47042b/raw/41992420e40512ce10ea6189fea4a71b43cf020e/RecyclableImage.tsx).
-


### PR DESCRIPTION
## Description

I had an issue using FlashList with image components not rendering the correct image the first time that item renders as you scroll down or up. The fix is in the readme, its to display a white image until the correct Image URI renders.

I encountered this issue and received help from one of the shopify devs. I wanted to add it to the list of known issues as recommended by one of the shopify devs since this is an issue everyone who uses iOS will have with a similar use case of rendering images in a FlashList


## Screenshots or videos (if needed)

Flickering before wrapping Image in RecyclableImage: (You can see the bar Gray Dog's img didn't render correctly at first)

https://user-images.githubusercontent.com/96435669/208005914-224d1b0a-24a7-4e7c-baab-3c484d649ee7.mov

No flickering after wrapping Image in RecyclableImage:


https://user-images.githubusercontent.com/96435669/208006132-758ceb9c-586e-4062-87fe-2e0d61b91e1e.mov

