### PR TITLE
Hide sticky overflow for Section List

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -321,7 +321,7 @@ class FlashList<T> extends React.PureComponent<
         style={
           this.props.horizontal
             ? { ...this.getTransform() }
-            : { flex: 1, ...this.getTransform() }
+            : { flex: 1, overflow: "hidden", ...this.getTransform() }
         }
       >
         <ProgressiveListView


### PR DESCRIPTION
## Description

Fixes #528

When a view was placed above a sticky header with Flash List the header would overflow that view (see video in original ticket). This PR removes that problem. 

## Reviewers’ hat-rack :tophat:

**Note: I couldn't get the e2e tests to run on my machine. Please run them on your end before approving.** 

1. In `fixture/src/contacts/Contacts.tsx` copy and paste this code into the render function
```
  return (
    <View style={{ flex: 1 }}>
      <View style={{ height: 100 }} />
      <View style={{ height: "100%" }}>
        <FlashList
          testID="FlashList"
          estimatedItemSize={44}
          data={data}
          renderItem={({ item }) => {
            if (typeof item === "string") {
              return <ContactSectionHeader title={item} />;
            } else {
              return <ContactCell contact={item as Contact} />;
            }
          }}
          getItemType={(item) => {
            return typeof item === "string" ? "sectionHeader" : "row";
          }}
          ItemSeparatorComponent={ContactDivider}
          stickyHeaderIndices={stickyHeaderIndices}
          ListHeaderComponent={ContactHeader}
          initialScrollIndex={debugContext.initialScrollIndex}
        />
      </View>
    </View>
  );
```

2. At this point if you scroll up, the sticky header in `Contacts` should NOT overflow the blank space above it. If you are in main, the sticky header would have gone over the empty space

## Screenshots or videos (if needed)

https://user-images.githubusercontent.com/48887088/208444025-019a3d3c-916c-4b5e-a0e3-d7a2fa81ed9e.mov

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
