### PR TITLE
Fix footer should not run without fix layout

### DIFF
--- a/ios/Sources/AutoLayoutView.swift
+++ b/ios/Sources/AutoLayoutView.swift
@@ -48,7 +48,6 @@ import UIKit
 
     override func layoutSubviews() {
         fixLayout()
-        fixFooter()
         super.layoutSubviews()
 
         let scrollView = getScrollView()
@@ -103,6 +102,7 @@ import UIKit
             }
             .sorted(by: { $0.index < $1.index })
         clearGaps(for: cellContainers)
+        fixFooter()
     }
 
     /// Checks for overlaps or gaps between adjacent items and then applies a correction.


### PR DESCRIPTION
## Description

resolves #

On iOS fix footer can run even when layout correction is skipped. This can lead to issues with height adjustments on parent view and can lead to many issues like element not being clickable is parent becomes smaller than children. This PR ensures that fix footer runs after fixing layout.

## Reviewers’ hat-rack :tophat:

Regression only

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
