### PR TITLE
fix: replacing transform scale style for android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Replacing android styles from `{ transform: [{ scaleX: -1 }] }` to `{ scaleY: -1 }` to fix inverted list performance issues
+
 ## [1.4.1] - 2023-01-24
 
 - Prevent overflow of sticky headers

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -5,6 +5,7 @@ import {
   LayoutChangeEvent,
   NativeSyntheticEvent,
   StyleSheet,
+  Platform,
   NativeScrollEvent,
 } from "react-native";
 import {
@@ -69,7 +70,10 @@ class FlashList<T> extends React.PureComponent<
   private rlvRef?: RecyclerListView<RecyclerListViewProps, any>;
   private stickyContentContainerRef?: PureComponentWrapper;
   private listFixedDimensionSize = 0;
-  private transformStyle = { transform: [{ scaleY: -1 }] };
+  private transformStyle =
+    Platform.OS === "android"
+      ? { scaleY: -1 }
+      : { transform: [{ scaleY: -1 }] };
   private transformStyleHorizontal = { transform: [{ scaleX: -1 }] };
   private distanceFromWindow = 0;
   private contentStyle: ContentStyleExplicit = {


### PR DESCRIPTION
Updating the transform style for android from `{ transform: [{ scaleX: -1 }] }` to `{ scaleY: -1 }`

Fixes https://github.com/Shopify/flash-list/issues/751

This issue seems to mostly impact android 13 phones where inverted is `true`. Can see a video of it happening on https://github.com/Shopify/flash-list/issues/751

## Reviewers’ hat-rack :tophat:

On an android 13 with a decently sized list you should be able to scroll and fetch extraData without frame drops or ANR issues

## Checklist

- [X] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
