### PR TITLE
Fix unsafe call on classLoader in `AutoLayoutShadowTest` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fix `getTestModel` failing in `AutoLayoutShadowTest` due to unsafe call on classLoader
+
 ## [1.4.1] - 2023-01-24
 
 - Prevent overflow of sticky headers

--- a/android/src/test/java/com/shopify/reactnative/flash_list/AutoLayoutShadowTest.kt
+++ b/android/src/test/java/com/shopify/reactnative/flash_list/AutoLayoutShadowTest.kt
@@ -123,7 +123,7 @@ internal class AutoLayoutShadowTest {
     }
 
     private fun getTestModel(): TestDataModel {
-        var str = this.javaClass.classLoader.getResource("LayoutTestData.json").readText()
+        var str = this.javaClass.classLoader?.getResource("LayoutTestData.json")?.readText()
         return gson.fromJson<TestDataModel>(str, TestDataModel::class.java)
     }
 


### PR DESCRIPTION
## Description

Fixes an issue where `AutoLayoutShadowTest::getTestModel` will fail because `this.javaClass.classLoader` is nullable and an unsafe call is being made on it.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ] Make sure this change doesn't introduce any new build issues

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
