### PR TITLE
fix: add backticks in JSDoc

### DIFF
--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -56,6 +56,7 @@ export interface FlashListProps<TItem> extends ScrollViewProps {
    * );
    * ...
    * <FlashList data={[{title: 'Title Text', key: 'item1'}]} renderItem={renderItem} />
+   * ```
    *
    * Provides additional metadata like `index`
    *


### PR DESCRIPTION
## Description

Hey, this PR adds backticks to JSDoc in `renderItem` description. 

## Screenshots

Before:
<img width="554" alt="CleanShot 2023-03-10 at 16 47 35@2x" src="https://user-images.githubusercontent.com/52801365/224360606-334c4430-afd3-402b-accd-4f88bd7c5a51.png">


After:
<img width="645" alt="CleanShot 2023-03-10 at 16 46 55@2x" src="https://user-images.githubusercontent.com/52801365/224360498-057cbb07-d4f7-488a-8825-1282185178de.png">


## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
