### PR TITLE
doc: add showsVerticalScrollIndicator documentation

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -596,6 +596,14 @@ Param `offset` expects the offset to scroll to. In case of `horizontal` is true,
 
 Param `animated` (`false` by default) defines whether the list should do an animation while scrolling.
 
+### `showsVerticalScrollIndicator`
+
+```tsx
+showsVerticalScrollIndicator?: boolean;
+```
+
+Show scroll indicator (scroll bar)
+
 # ScrollView props
 
 `FlashList`, as `FlatList`, uses `ScrollView` under the hood. You can take a look into the React Native documentation for [`ScrollView`](https://reactnative.dev/docs/scrollview) to see the exhaustive list of props.


### PR DESCRIPTION
## Description

Fixes (issue #)
showsVerticalScrollIndicator prop is missing from the documentation page

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
