### PR TITLE
Fix definition conflicts with previous value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix definition conflicts with previous value
 
 ## [1.4.2] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 - Fix definition conflicts with previous value
+  - https://github.com/Shopify/flash-list/pull/795
 
 ## [1.4.2] - 2023-03-20
 

--- a/ios/Sources/AutoLayoutView.swift
+++ b/ios/Sources/AutoLayoutView.swift
@@ -50,8 +50,7 @@ import UIKit
         fixLayout()
         super.layoutSubviews()
 
-        let scrollView = getScrollView()
-        guard enableInstrumentation, let scrollView = scrollView else { return }
+        guard enableInstrumentation, let scrollView = getScrollView() else { return }
 
         let scrollContainerSize = horizontal ? scrollView.frame.width : scrollView.frame.height
         let currentScrollOffset = horizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y


### PR DESCRIPTION
## Description

Fixes #794

This PR fixes the `scrollview` variable initialization duplicity error.

## Reviewers’ hat-rack :tophat:

- [ ]  Make sure nothing regressed in how FlashList worked before.
- [ ]  Make sure that iOS build is working.

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [X] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
