### PR TITLE
Fix failing build due to scrollView definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fix build errors on older Swift and Xcode versions
+  - https://github.com/Shopify/flash-list/pull/800
+
 ## [1.4.2] - 2023-03-20
 
 - Apply layout correction only to consecutive cells

--- a/ios/Sources/AutoLayoutView.swift
+++ b/ios/Sources/AutoLayoutView.swift
@@ -50,8 +50,7 @@ import UIKit
         fixLayout()
         super.layoutSubviews()
 
-        let scrollView = getScrollView()
-        guard enableInstrumentation, let scrollView = scrollView else { return }
+        guard enableInstrumentation, let scrollView = getScrollView() else { return }
 
         let scrollContainerSize = horizontal ? scrollView.frame.width : scrollView.frame.height
         let currentScrollOffset = horizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/flash-list/issues/794

On older Xcode versions, the current syntax of:
```swift
let scrollView = getScrollView()
guard let scrollView = scrollView else { return }
```

is not valid. There's no drawback to doing:
```swift
guard let scrollView = getScrollView() else { return }
```

I'd say it's even more readable. The change should fix the build error in the attached issue.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- Test out fixture app

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
