### PR TITLE
fix: prevent __DEV__ is not defined on web

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  Platform,
   View,
   RefreshControl,
   LayoutChangeEvent,
@@ -140,6 +141,7 @@ class FlashList<T> extends React.PureComponent<
     // `createAnimatedComponent` always passes a blank style object. To avoid warning while using AnimatedFlashList we've modified the check
     // `style` prop can be an array. So we need to validate every object in array. Check: https://github.com/Shopify/flash-list/issues/651
     if (
+      Platform.OS !== 'web' &&
       __DEV__ &&
       Object.keys(StyleSheet.flatten(this.props.style ?? {})).length > 0
     ) {


### PR DESCRIPTION
## Description

Fixes (issue #)

```
error boundary ReferenceError: __DEV__ is not defined
    at FlashList.validateProps (FlashList.tsx:142:1)
    at new FlashList (FlashList.tsx:110:1)
    at constructClassInstance (react-dom.development.js:14323:1)
    at updateClassComponent (react-dom.development.js:19688:1)
    at beginWork (react-dom.development.js:21611:1)
    at beginWork$1 (react-dom.development.js:27426:1)
    at performUnitOfWork (react-dom.development.js:26557:1)
    at workLoopSync (react-dom.development.js:26466:1)
    at renderRootSync (react-dom.development.js:26434:1)
    at performSyncWorkOnRoot (react-dom.development.js:26085:1) 
```

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
