### PR TITLE
fix: add mock for animated flashlist

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -11,5 +11,6 @@ jest.mock("@shopify/flash-list", () => {
   return {
     ...jest.requireActual("@shopify/flash-list"),
     FlashList: MockFlashList,
+    AnimatedFlashList: MockFlashList,
   };
 });


### PR DESCRIPTION
## Description

Fixes (issue #825)

Mocks are added for FlashList only, this results in failing tests for `AnimatedFlashList` usage.
I'm importing `AnimatedFlashList` as follows.

```js
import { AnimatedFlashList } from '@shopify/flash-list';
```

This PR adds mocks for `AnimatedFlashList`, which is same as `FlashList`

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
