### PR TITLE
Add "npx" to the landing page's Expo setup instructions

### DIFF
--- a/website/_includes/install_expo.sh
+++ b/website/_includes/install_expo.sh
@@ -1,1 +1,1 @@
-expo install @shopify/flash-list
+npx expo install @shopify/flash-list


### PR DESCRIPTION
## Description

This changes `expo install` to `npx expo install`, which matches the instructions on https://shopify.github.io/flash-list/docs/ and is the way to invoke the modern Expo CLI.

## Screenshots or videos (if needed)

Tested by building the website locally with `bundle exec jekyll build` and opening _site/index.html.

<img width="1154" alt="Screenshot 2023-04-25 at 7 55 40 PM" src="https://user-images.githubusercontent.com/379606/234455834-b868ad07-7ec6-4952-ab2c-2c0adc690433.png">

## Checklist

Didn't think this needed a changelog since it doesn't affect the library itself.