### PR TITLE
Fix crash if estimatedItemSize is NaN

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -730,6 +730,13 @@ class FlashList<T> extends React.PureComponent<
         );
       }, 1000);
     }
+    if (isNaN(this.props.estimatedItemSize)) {
+      this.props.estimatedItemSize = null;
+      console.warn(
+        "Warning: estimatedItemSize is NaN. estimatedItemSize has been reset to null which can caouse performance issues. Please verify your item size calculations to ensure accurate results."
+      );
+    }
+
     this.postLoadTimeoutId = setTimeout(() => {
       // This force update is required to remove dummy element rendered to measure horizontal list height when  the list doesn't update on its own.
       // In most cases this timeout will never be triggered because list usually updates atleast once and this timeout is cleared on update.


### PR DESCRIPTION
## Description

Fixes (issue #)
This PR fixes a crash caused by the estimatedItemSize having a NaN value in some cases. (I came across with the problem when I was developing a Carousel component where I was calculating the estimatedItemSize inside of a useCallback.) The application now checks for NaN values and sets estimatedItemSize to null, which prevents the crash. However, this may cause performance issues, so a warning message is displayed in the console to alert developers about the potential problem.

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist
- Check if the implemented solution prevents crashes caused by NaN estimatedItemSize values.
- Check if the implemented solution prevents crashes caused by NaN estimatedItemSize values.

### Fixed
-estimatedItemSize is NaN check

