### PR TITLE
Handle invalid padding values in contentContainerStyle

### DIFF
--- a/src/__tests__/ContentContainerUtils.test.ts
+++ b/src/__tests__/ContentContainerUtils.test.ts
@@ -67,6 +67,14 @@ describe("ContentContainerUtils", () => {
       paddingLeft: 1,
       paddingRight: 0,
     });
+    expect(
+      updateContentStyle({}, { paddingLeft: "invalid", paddingVertical: "1%" })
+    ).toEqual({
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+    });
   });
   it("computes correct layout manager insets", () => {
     expect(

--- a/src/utils/ContentContainerUtils.ts
+++ b/src/utils/ContentContainerUtils.ts
@@ -26,17 +26,17 @@ export const updateContentStyle = (
     backgroundColor,
   } = (contentContainerStyleSource ?? {}) as ViewStyle;
   contentStyle.paddingLeft = Number(
-    paddingLeft || paddingHorizontal || padding || 0
-  );
+    paddingLeft || paddingHorizontal || padding
+  ) || 0;
   contentStyle.paddingRight = Number(
-    paddingRight || paddingHorizontal || padding || 0
-  );
+    paddingRight || paddingHorizontal || padding
+  ) || 0;
   contentStyle.paddingTop = Number(
-    paddingTop || paddingVertical || padding || 0
-  );
+    paddingTop || paddingVertical || padding
+  ) || 0;
   contentStyle.paddingBottom = Number(
-    paddingBottom || paddingVertical || padding || 0
-  );
+    paddingBottom || paddingVertical || padding
+  ) || 0;
   contentStyle.backgroundColor = backgroundColor;
   return contentStyle as ContentStyleExplicit;
 };


### PR DESCRIPTION
## Description

When passing an invalid value for padding in `contentContainerStyle` on the web, the component starts blowing up the CPU. It was possible to pass NaN down the style since Number("invalid") is a number(NaN) 🤣 

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
