### PR TITLE
Fixes a crash caused by the reanimated library object freeze

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -408,13 +408,13 @@ class FlashList<T> extends React.PureComponent<
     // If the initial scroll index is in the first row then we're forcing RLV to use initialOffset and thus we need to disable window correction
     // This isn't clean but it's the only way to get RLV to scroll to the right place
     // TODO: Remove this when RLV fixes this. Current implementation will also fail if column span is overridden in the first row.
-    if (this.isInitialScrollIndexInFirstRow()) {
-      this.windowCorrectionConfig.applyToInitialOffset = false;
-    } else {
-      this.windowCorrectionConfig.applyToInitialOffset = true;
-    }
-    this.windowCorrectionConfig.value.windowShift = -this.distanceFromWindow;
-    return this.windowCorrectionConfig;
+    const applyToInitialOffset = !this.isInitialScrollIndexInFirstRow();
+    const windowShift = -this.distanceFromWindow;
+    return (this.windowCorrectionConfig = {
+      ...this.windowCorrectionConfig,
+      applyToInitialOffset,
+      value: { ...this.windowCorrectionConfig.value, windowShift },
+    });
   }
 
   private isInitialScrollIndexInFirstRow() {


### PR DESCRIPTION
## Description

Since Reanimated 3.0 they added [shareables.ts](https://github.com/software-mansion/react-native-reanimated/blob/c35c122eadae6a4a8027f82368e958f0e9ae8359/src/reanimated2/shareables.ts) recursively freezing objects that can possibly share values and one of it is `windowCorrectionConfig` we mutate. If we use Reanimated.ScrollView inside `renserScrollComponent` props then we get the error that we cannot mutate `windowCorrectionConfig.applyToInitialOffset`.

To get around this issue, we don't mutate `windowCorrectionConfig` directly, instead we create a new `windowCorrectionConfig` object with the updated values and reassign it.

Reproducing the case in Fixture would have needed to update Reanimated and React-Native which was not easily doable with the time we had. 

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
