### PR TITLE
Doc for the ListEmptyComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Improve ListEmptyComponent documentation
+ - https://github.com/Shopify/flash-list/pull/878
+
 ## [1.5.0] - 2023-07-12
 
 - Update kotlin version to 1.8.10 for RN 0.72 compatibility

--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -149,7 +149,7 @@ ItemSeparatorComponent?: React.ComponentType<any>;
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`). Please note that the `ListFooterComponent` and `ListHeaderComponent` will also be rendered if the list is empty.
 
 ```tsx
 ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<any, string | React.JSXElementConstructor<any>>;


### PR DESCRIPTION
## Description

Explain in the documentation that the `ListHeaderComponent` and `ListFooterComponent` will still be rendered if the list is empty and that the `ListEmptyComponent` is specified.

## Reviewers’ hat-rack :tophat:

- [ ]

## Screenshots or videos (if needed)

<img width="1436" alt="image" src="https://github.com/Shopify/flash-list/assets/87643625/822a76f9-e9b3-42d5-922f-a1ee045fbd0a">


## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
