### PR TITLE
Update usage.md: add note about scroll component ref

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -461,7 +461,7 @@ renderScrollComponent?:
     | React.FC<ScrollViewProps>;
 ```
 
-Rendered as the main scrollview.
+Rendered as the main scrollview. When set, make sure your scroll component uses the ref given to it.
 
 ### `viewabilityConfig`
 


### PR DESCRIPTION
This is just a small docs update.

When using `renderScrollComponent`, if you don't use the ref passed to your component, `scrollTo*` won't work.

I decided not to mention what wouldn't work if you didn't follow this suggestion, but I can if you like. 

Also, I'm not sure if I should explicitly mention `forwardRef` or not.