### PR TITLE
Add option to clear layout cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Update types to match `react-native@0.72` view types.
   - https://github.com/Shopify/flash-list/pull/890
+- Add option to clear cached layouts on update
+  - https://github.com/Shopify/flash-list/pull/910
 
 ## [1.5.0] - 2023-07-12
 

--- a/fixture/ios/Podfile.lock
+++ b/fixture/ios/Podfile.lock
@@ -366,9 +366,9 @@ PODS:
     - React-Core
     - SDWebImage (~> 5.11.1)
     - SDWebImageWebPCoder (~> 0.8.4)
-  - RNFlashList (1.4.3):
+  - RNFlashList (1.5.0):
     - React-Core
-  - RNFlashList/Tests (1.4.3):
+  - RNFlashList/Tests (1.5.0):
     - React-Core
   - RNGestureHandler (2.5.0):
     - React-Core
@@ -630,7 +630,7 @@ SPEC CHECKSUMS:
   ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
   ReactNativePerformanceListsProfiler: b9f7cfe8d08631fbce8e4729d388a5a3f7f562c2
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
-  RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
+  RNFlashList: 25b0e092b4470c84db0386d4f5316dc34123bb6d
   RNGestureHandler: bad495418bcbd3ab47017a38d93d290ebd406f50
   RNReanimated: 3d1432ce7b6b7fc31f375dcabe5b4585e0634a43
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -840,6 +840,13 @@ class FlashList<T> extends React.PureComponent<
   }
 
   /**
+   * FlashList will skip using layout cache on next update. Can be useful when you know the layout will change drastically for example, orientation change when used as a carousel.
+   */
+  public clearLayoutCacheOnUpdate() {
+    this.state.layoutProvider.markExpired();
+  }
+
+  /**
    * Tells the list an interaction has occurred, which should trigger viewability calculations, e.g. if waitForInteractions is true and the user has not scrolled.
    * This is typically called by taps on items or by navigation actions.
    */

--- a/src/GridLayoutProviderWithProps.ts
+++ b/src/GridLayoutProviderWithProps.ts
@@ -92,6 +92,13 @@ export default class GridLayoutProviderWithProps<T> extends GridLayoutProvider {
   }
 
   /**
+   * Calling this method will mark the layout provider as expired. As a result, a new one will be created by FlashList and old cached layouts will be discarded.
+   */
+  public markExpired() {
+    this._hasExpired = true;
+  }
+
+  /**
    * Calling this method will help the layout provider track average item sizes on its own
    * Overriding layout manager can help achieve the same thing without relying on this method being called however, it will make implementation very complex for a simple use case
    * @param index Index of the item being reported


### PR DESCRIPTION
## Description

Cached layouts can be a problem in a few cases like changing orientation while having `pagingEnabled` set to `true`. Introducing a way to clear them if required but developers will need to decide given that they do help with performance when list size changes.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

N/A

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
