### PR TITLE
Prevent expired flag from resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.6.1] - 2023-09-14
+
+- Prevent an expired layout provider from being used again
+  - https://github.com/Shopify/flash-list/pull/915
+
 ## [1.6.0] - 2023-09-13
 
 - Update types to match `react-native@0.72` view types.

--- a/src/GridLayoutProviderWithProps.ts
+++ b/src/GridLayoutProviderWithProps.ts
@@ -65,7 +65,6 @@ export default class GridLayoutProviderWithProps<T> extends GridLayoutProvider {
   }
 
   public updateProps(props: FlashListProps<T>): GridLayoutProviderWithProps<T> {
-    this._hasExpired = this.props.numColumns !== props.numColumns;
     const newInsetValues = applyContentContainerInsetForLayoutManager(
       {
         height: 0,
@@ -76,6 +75,7 @@ export default class GridLayoutProviderWithProps<T> extends GridLayoutProvider {
     );
     this._hasExpired =
       this._hasExpired ||
+      this.props.numColumns !== props.numColumns ||
       newInsetValues.height !== this.renderWindowInsets.height ||
       newInsetValues.width !== this.renderWindowInsets.width;
     this.renderWindowInsets = newInsetValues;


### PR DESCRIPTION
## Description

`expired` flag in layout provider was getting reset in the `updateProps` method. This PR addresses the issue

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

N/A

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
