### PR TITLE
Fix link to Layout Animation docs in FlashListProps keyExtractor

### DIFF
--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -195,7 +195,7 @@ export interface FlashListProps<TItem> extends ScrollViewProps {
   /**
    * Used to extract a unique key for a given item at the specified index.
    * Key is used for optimizing performance. Defining `keyExtractor` is also necessary
-   * when doing [layout animations](https://flash-list.docs.shopify.io/guides/layout-animation)
+   * when doing [layout animations](https://shopify.github.io/flash-list/docs/guides/layout-animation)
    * to uniquely identify animated components.
    */
   keyExtractor?: ((item: TItem, index: number) => string) | undefined;


### PR DESCRIPTION
## Description

Fixes a link to the layout animation docs within the code for `FlashListProps`

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
