### PR TITLE
Make isItemViewable handle floating point error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Make `onViewableItemsChanged` better handle floating-point error.
+
 ## [1.6.3] - 2023-11-09
 
 - Changes for RN 0.73 support

--- a/src/viewability/ViewabilityHelper.ts
+++ b/src/viewability/ViewabilityHelper.ts
@@ -138,7 +138,8 @@ class ViewabilityHelper {
       Math.min(itemTop + itemSize, listMainSize) - Math.max(itemTop, 0);
 
     // Always consider item fully viewable if it is fully visible, regardless of the `viewAreaCoveragePercentThreshold`
-    if (pixelsVisible === itemSize) {
+    // Account for floating point imprecision.
+    if (Math.abs(pixelsVisible - itemSize) <= 0.001) {
       return true;
     }
     // Skip checking item if it's not visible at all


### PR DESCRIPTION
## Description

I'm not sure there is an issue for this. I can create one if necessary.

While working on a react-native app, I noticed that _some_ views would never initially appear as visible according to `onViewableItemsChanged`. From debugging, I isolated the issue to `ViewabilityHelper`'s `isItemViewable`. https://github.com/Shopify/flash-list/blob/main/src/viewability/ViewabilityHelper.ts#L141

I'm not able to share a video or repro, I'm pretty certain that what I'm seeing is minute differences between `pixelsVisible` and `itemSize`. For an example view, I get `pixelsVisible = 36.761904761904816` and `itemSize = 36.76190476190476`. I feel like that these differences are likely caused by floating-errors from prior calculations.

## Reviewers’ hat-rack :tophat:

- [ ] Do you agree with my hypothesis and reasoning?
- [ ] Should I alternatively do `if (pixelsVisible - itemSize >= -0.001)`? i.e. allow `pixelsVisible` to be greater than `itemSize` in general?
- [ ] Is `0.001` a suitable arbitrary number?

## Screenshots or videos (if needed)

Unfortunately I cannot provide this easily. :(

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
