### PR TITLE
fix: item separator with inverted flashlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fix `ItemSeparatorComponent ` position for the `inverted` flashlist
+  - https://github.com/Shopify/flash-list/pull/1046
+
 ## [1.6.3] - 2023-11-09
 
 - Changes for RN 0.73 support

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -662,6 +662,7 @@ class FlashList<T> extends React.PureComponent<
   private getCellContainerChild = (index: number) => {
     return (
       <>
+        {this.props.inverted ? this.separator(index) : null}
         <View
           style={{
             flexDirection:
@@ -672,7 +673,7 @@ class FlashList<T> extends React.PureComponent<
         >
           {this.rowRendererWithIndex(index, RenderTargetOptions.Cell)}
         </View>
-        {this.separator(index)}
+        {this.props.inverted ? null : this.separator(index)}
       </>
     );
   };


### PR DESCRIPTION
## Description
This pr fixes the `ItemSeparatorComponent ` position for the `inverted` flashlist. Thanks to @mkhoussid for suggesting this fix. I tested in my app and it worked
Fixes (issue #)
fixes #638
<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
