### PR TITLE
Centralize Ruby Version to `.ruby-version`

### DIFF
--- a/.github/workflows/flash-list.yml
+++ b/.github/workflows/flash-list.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 env:
-  RUBY_VERSION: 3.0.3
   NODE_VERSION: 20.4.0
 
 jobs:
@@ -133,7 +132,6 @@ jobs:
       - name: Ruby setup
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - name: Install dependencies
         run: |

--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,6 @@
 name: FlashList
 
 up:
-  - ruby: 3.0.3
+  - ruby
   - bundler
   - yarn_install


### PR DESCRIPTION
## What are you trying to accomplish?
The `.ruby-version` file is the ecosystem standard for defining a Ruby version.  This PR adds the `.ruby-version` file, and removes all other references to Ruby in this repository, aligning it with the standard.
## What should reviewers focus on?
> [!IMPORTANT] 
> Please verify the following before merging:

Verify that the changes in the PR meets the following requirements or adjust manually to make it compliant:
  - [x] `.ruby-version` file is present with the correct Ruby version defined
  - [x] There is no Ruby version present in the  `dev.yml` Ruby task (before: `- ruby: x.x.x`, after: `- ruby`)
  - [x] There is no Ruby version/requirement referenced in the `Gemfile` (no lines with `ruby  <some-version>`)
  - [x] A `Gemfile.lock` is built with the defined Ruby version
  - [x] There is no `TargetRubyVersion` defined  in `rubocop.yml` 
  - [x] There is no Ruby argument  present in  `ruby/setup-ruby` Github Actions (no lines with `ruby-version: “x.x”`)

Please merge this PR if it looks good, this PR will be merged if there isn't any activity after 4 weeks.
