### PR TITLE
Fix stale reference to onScroll and onLoad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Update internal dependency and fixture app to `react-native@0.72`.
   - https://github.com/Shopify/flash-list/pull/1076
+- Fix stale reference to onScroll and onLoad
+  - https://github.com/Shopify/flash-list/pull/1112
 
 ## [1.6.4] - 2024-03-18
 

--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -114,6 +114,9 @@ const MasonryFlashListComponent = React.forwardRef(
 
     const totalColumnFlex = useTotalColumnFlex(dataSet, props);
 
+    const propsRef = useRef(props);
+    propsRef.current = props;
+
     const onScrollRef = useRef<OnScrollCallback[]>([]);
     const emptyScrollEvent = useRef(getEmptyScrollEvent())
       .current as NativeSyntheticEvent<MasonryFlashListScrollEvent>;
@@ -135,7 +138,7 @@ const MasonryFlashListComponent = React.forwardRef(
           onScrollCallback?.(emptyScrollEvent);
         });
         if (!scrollEvent.nativeEvent.doNotPropagate) {
-          props.onScroll?.(scrollEvent);
+          propsRef.current.onScroll?.(scrollEvent);
         }
       }
     ).current;
@@ -151,7 +154,7 @@ const MasonryFlashListComponent = React.forwardRef(
         onScrollProxy?.(emptyScrollEvent);
         emptyScrollEvent.nativeEvent.doNotPropagate = false;
       }, 32);
-      props.onLoad?.(args);
+      propsRef.current.onLoad?.(args);
     }).current;
 
     const [parentFlashList, getFlashList] =


### PR DESCRIPTION
## Description

resolves #689 

We had stable callbacks referring to props. For now we capture props in a ref which is updated everytime. Keeps the scope of the change small and fixes the problem.

## Reviewers’ hat-rack :tophat:

Check if onLoad callback is still working when masonry sample loads.

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
