### PR TITLE
Add "arm64-darwin-22" as a platform for Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   universal-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20


### PR DESCRIPTION
## Description

Adds `arm64-darwin-22` as a valid container in the `Gemfile.lock` file.

This should fix the currently broken `Ruby setup` GH action step:
- https://github.com/Shopify/flash-list/actions/runs/8988990989/job/24691074146

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- CI should ✅ 
