### PR TITLE
Fix RangeError if estimatedSize={0}

### DIFF
--- a/src/GridLayoutProviderWithProps.ts
+++ b/src/GridLayoutProviderWithProps.ts
@@ -131,7 +131,7 @@ export default class GridLayoutProviderWithProps<T> extends GridLayoutProvider {
         (this.props.horizontal
           ? renderWindowSize.width
           : renderWindowSize.height) /
-          (this.props.estimatedItemSize ?? this.defaultEstimatedItemSize)
+          (this.props.estimatedItemSize || this.defaultEstimatedItemSize)
       )
     );
     this.averageWindow = new AverageWindow(


### PR DESCRIPTION
## Description

If the `estimatedSize` is set to `0` (could be by accident or before the final value is calculated), the FlashList would throw 

```
RangeError: Array size is not a small enough positive integer.
```

Root cause code:
https://github.com/Shopify/flash-list/blob/cb9c30f1be11e85c726bb7a0ae82692f2e79bb11/src/GridLayoutProviderWithProps.ts#L128-L136

The error is due to the using `??` instead of `||`, so the `estimatedItemCount` would divide the `renderWindowSize` with `0`. Then the value of `estimatedItemCount` would be `Infinity`.

This value is later passed to new instance of `AverageWindow` as `size` as `Infinity`. 

The actual error is thrown from this line:
https://github.com/Shopify/flash-list/blob/cb9c30f1be11e85c726bb7a0ae82692f2e79bb11/src/utils/AverageWindow.ts#L4-L10

Creating `new Array(Math.max(1, Infinity))` would throw the **RangeError**.

<!--`
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
