### PR TITLE
Load library code from the src directory in react-native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Added library code loading from the `src` directory
+  - https://github.com/Shopify/flash-list/pull/1263
+
 ## [1.7.0] - 2024-07-03
 
 - Update internal dependency and fixture app to `react-native@0.72`.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "homepage": "https://shopify.github.io/flash-list/",
   "main": "dist/index.js",
+  "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {
     "up": "bundle install && yarn fixture:rn:up && yarn e2e:up && yarn build",


### PR DESCRIPTION
## Description

This PR adds just `"react-native"` entry in the `package.json` file that allows library code to be loaded from the included `src` directory instead of the transpiled JS code in the `dist` directory.

It just will use source files when possible. It makes library patching much easier because changes in the source code are necessary (instead of the processed JS files).

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
