### PR TITLE
docs: Remove development client usage for Expo

### DIFF
--- a/documentation/docs/index.mdx
+++ b/documentation/docs/index.mdx
@@ -36,7 +36,7 @@ feature, you will need to manually link the dependency - read
 </TabItem>
 <TabItem value="expo">
 
-- ✅ This library can be used with "Expo Go" from SDK 46 upwards or with a development client
+- ✅ This library can be used with "Expo Go" from SDK 46 upwards.
 - ✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
 
 ```bash


### PR DESCRIPTION
## Description

I noticed that the current documentation mentions development clients with Expo, and then in the next sentence, it mentions development builds. Conceptually, both of these are the same for user-facing information. A development build is something that contains `expo-dev-client` library (the library is called development client).

Removing usage of development clients makes sure that information is focused on Expo Go and development builds, and for a developer using this library in a project created with Expo, both of those methods work.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->


## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

N/A

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
