### PR TITLE
Create recomputeViewableItems method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Add recomputeViewableItems method
+  - https://github.com/Shopify/flash-list/pull/1296
+
 ## [1.7.0] - 2024-07-03
 
 - Update internal dependency and fixture app to `react-native@0.72`.

--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -549,6 +549,14 @@ recordInteraction();
 
 Tells the list an interaction has occurred, which should trigger viewability calculations, e.g. if `waitForInteractions` is true and the user has not scrolled. You should typically call `recordInteraction()` when user for example taps on an item or invokes a navigation action.
 
+### `recomputeViewableItems()`
+
+```tsx
+recomputeViewableItems();
+```
+
+Retriggers viewability calculations. Useful to imperatively trigger viewability calculations.
+
 ### `scrollToEnd()`
 
 ```tsx

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -870,6 +870,13 @@ class FlashList<T> extends React.PureComponent<
   public recordInteraction = () => {
     this.viewabilityManager.recordInteraction();
   };
+
+  /**
+   * Retriggers viewability calculations. Useful to imperatively trigger viewability calculations.
+   */
+  public recomputeViewableItems = () => {
+    this.viewabilityManager.recomputeViewableItems();
+  };
 }
 
 export default FlashList;

--- a/src/__tests__/FlashList.test.tsx
+++ b/src/__tests__/FlashList.test.tsx
@@ -551,6 +551,121 @@ describe("FlashList", () => {
     });
   });
 
+  it("retrigers viewability events when recomputeViewableItems is called", () => {
+    const onViewableItemsChanged = jest.fn();
+    const flashList = mountFlashList({
+      estimatedItemSize: 300,
+      onViewableItemsChanged,
+      viewabilityConfig: {
+        itemVisiblePercentThreshold: 50,
+        minimumViewTime: 0,
+      },
+    });
+
+    // Initial viewable items
+    expect(onViewableItemsChanged).toHaveBeenCalledWith({
+      changed: [
+        {
+          index: 0,
+          isViewable: true,
+          item: "One",
+          key: "0",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 1,
+          isViewable: true,
+          item: "Two",
+          key: "1",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 2,
+          isViewable: true,
+          item: "Three",
+          key: "2",
+          timestamp: expect.any(Number),
+        },
+      ],
+      viewableItems: [
+        {
+          index: 0,
+          isViewable: true,
+          item: "One",
+          key: "0",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 1,
+          isViewable: true,
+          item: "Two",
+          key: "1",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 2,
+          isViewable: true,
+          item: "Three",
+          key: "2",
+          timestamp: expect.any(Number),
+        },
+      ],
+    });
+
+    onViewableItemsChanged.mockClear();
+
+    flashList.instance.recomputeViewableItems();
+
+    expect(onViewableItemsChanged).toHaveBeenCalledWith({
+      changed: [
+        {
+          index: 0,
+          isViewable: true,
+          item: "One",
+          key: "0",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 1,
+          isViewable: true,
+          item: "Two",
+          key: "1",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 2,
+          isViewable: true,
+          item: "Three",
+          key: "2",
+          timestamp: expect.any(Number),
+        },
+      ],
+      viewableItems: [
+        {
+          index: 0,
+          isViewable: true,
+          item: "One",
+          key: "0",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 1,
+          isViewable: true,
+          item: "Two",
+          key: "1",
+          timestamp: expect.any(Number),
+        },
+        {
+          index: 2,
+          isViewable: true,
+          item: "Three",
+          key: "2",
+          timestamp: expect.any(Number),
+        },
+      ],
+    });
+  });
+
   it("should not overlap header with sitcky index 0", () => {
     const HeaderComponent = () => {
       return <Text>Empty</Text>;

--- a/src/viewability/ViewabilityHelper.ts
+++ b/src/viewability/ViewabilityHelper.ts
@@ -118,6 +118,10 @@ class ViewabilityHelper {
     }
   }
 
+  public clearLastReportedViewableIndices() {
+    this.lastReportedViewableIndices = [];
+  }
+
   private isItemViewable(
     index: number,
     horizontal: boolean,

--- a/src/viewability/ViewabilityManager.ts
+++ b/src/viewability/ViewabilityManager.ts
@@ -88,6 +88,14 @@ export default class ViewabilityManager<T> {
     });
   };
 
+  public recomputeViewableItems = () => {
+    this.viewabilityHelpers.forEach((viewabilityHelper) =>
+      viewabilityHelper.clearLastReportedViewableIndices()
+    );
+
+    this.updateViewableItems();
+  };
+
   /**
    * Creates a new `ViewabilityHelper` instance with `onViewableItemsChanged` callback and `ViewabilityConfig`
    * @returns `ViewabilityHelper` instance


### PR DESCRIPTION
## Description

Adds `recomputeViewableItems` method to FlashList. Useful to imperatively trigger viewability calculations.  

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ] Validate that calling the `recomputeViewableItems` method triggers the `onViewableItemsChanged` callback.

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
