### PR TITLE
Pass `extraData` to `stickyOverrideRowRenderer`

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -695,7 +695,7 @@ class FlashList<T> extends React.PureComponent<
     _: any,
     __: any,
     index: number,
-    ___: any
+    extraData: any
   ) => {
     return (
       <PureComponentWrapper
@@ -703,6 +703,7 @@ class FlashList<T> extends React.PureComponent<
         enabled={this.isStickyEnabled}
         arg={index}
         renderer={this.rowRendererSticky}
+        extraData={extraData}
       />
     );
   };


### PR DESCRIPTION
In our usage of FlashList, we have a "selected" checkbox on the sticky header of each group. This header item allows the user to select all items in the group. However, when using sticky headers, selecting the group doesn't update the header row.

When these rows are stuck to the top, they don't update when `extraData` changes. When they come unstuck from the top, they update immediately. Regular header rows are updated when `extraData` changes, but these for some reason aren't.

We've been testing this locally and it works nicely. I don't know whether there's a specific reason that `extraData` is not included in sticky row renderers, but it seems reasonable that rows should behave the same way when they're stuck as they do when they're not stuck.

## Description

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
