### PR TITLE
fix: trigger onViewableItemsChanged when calling MasonryFlashList's recomputeViewableItems after data changed

### DIFF
--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -186,6 +186,27 @@ const MasonryFlashListComponent = React.forwardRef(
       false
     );
 
+    /*
+     * Add a Ref object to track all FlashList instances.
+     * So that we can call all their recomputeViewableItems method
+    */
+    const allColumnFlashListsRef = useRef<{ [columnIndex: number]: FlashList<T> | null }>({});
+
+    const recomputeAllViewableItems = useCallback(() => {
+      for (const columnIndex in allColumnFlashListsRef.current) {
+        allColumnFlashListsRef.current[columnIndex]?.recomputeViewableItems();
+      }
+    }, []);
+
+    useEffect(() => {
+      if (forwardRef) {
+        forwardRef.current = {
+          ...forwardRef.current,
+          recomputeViewableItems: recomputeAllViewableItems,
+        };
+      }
+    }, [forwardRef, recomputeAllViewableItems]);
+
     return (
       <FlashList
         ref={getFlashList}
@@ -198,6 +219,7 @@ const MasonryFlashListComponent = React.forwardRef(
         renderItem={(args) => {
           return (
             <FlashList
+              ref={(r) => allColumnFlashListsRef.current[Number(args.index)] = r}
               renderScrollComponent={ScrollComponent}
               estimatedItemSize={props.estimatedItemSize}
               data={args.item}


### PR DESCRIPTION
I am glad to see that [@Paduado has added the `recomputeViewableItems` method](https://github.com/Shopify/flash-list/pull/1296) to solve the problem that the `onViewableItemsChanged` will not be called after the FlashList's data is updated.
But the MasonryFlashList I used in my project did not enjoy this benefit.
So I changed the MasonryFlashList source code to achieve the same effect as FlashList.


## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ] Validate that calling the recomputeViewableItems method triggers the onViewableItemsChanged callback.

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
