### PR TITLE
[Add-ComponentProvider] refactor: add componentProvider to ios codege…

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
   "codegenConfig": {
     "name": "rnflashlist",
     "type": "components",
-    "jsSrcsDir": "./src/specs"
+    "jsSrcsDir": "./src/specs",
+    "ios": {
+      "componentProvider": {
+        "CellContainer": "CellContainerComponentView",
+        "AutoLayoutView": "AutoLayoutViewComponentView"
+      }
+    }
   }
 }


### PR DESCRIPTION

## Description

This pull request refactors the codegenConfig for the rnflashlist package by adding the componentProvider configuration specifically for iOS. This change enhances the iOS code generation by mapping CellContainer and AutoLayoutView to their respective component views (CellContainerComponentView and AutoLayoutViewComponentView). This should help improve modularity and maintainability for iOS-specific components.
Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
