### PR TITLE
feat: allow passing minHeight and minWidth to contentContainerStyle

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -202,6 +202,8 @@ export type ContentStyle = Pick<
   | "padding"
   | "paddingVertical"
   | "paddingHorizontal"
+  | "minWidth"
+  | "minHeight"
 >;
 ```
 

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -357,8 +357,8 @@ class FlashList<T> extends React.PureComponent<
               backgroundColor: this.contentStyle.backgroundColor,
 
               // Required to handle a scrollview bug. Check: https://github.com/Shopify/flash-list/pull/187
-              minHeight: 1,
-              minWidth: 1,
+              minHeight: this.contentStyle.minHeight || 1,
+              minWidth: this.contentStyle.minWidth || 1,
 
               ...getContentContainerPadding(this.contentStyle, horizontal),
             },

--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -45,6 +45,8 @@ export type ContentStyle = Pick<
   | "padding"
   | "paddingVertical"
   | "paddingHorizontal"
+  | "minHeight"
+  | "minWidth"
 >;
 
 export interface FlashListProps<TItem> extends ScrollViewProps {

--- a/src/utils/ContentContainerUtils.ts
+++ b/src/utils/ContentContainerUtils.ts
@@ -4,6 +4,8 @@ import { Dimension } from "recyclerlistview";
 import { ContentStyle } from "../FlashListProps";
 
 export interface ContentStyleExplicit {
+  minWidth: number;
+  minHeight: number;
   paddingTop: number;
   paddingBottom: number;
   paddingLeft: number;
@@ -24,6 +26,8 @@ export const updateContentStyle = (
     paddingVertical,
     paddingHorizontal,
     backgroundColor,
+    minWidth,
+    minHeight,
   } = (contentContainerStyleSource ?? {}) as ViewStyle;
   contentStyle.paddingLeft = Number(
     paddingLeft || paddingHorizontal || padding || 0
@@ -38,6 +42,8 @@ export const updateContentStyle = (
     paddingBottom || paddingVertical || padding || 0
   );
   contentStyle.backgroundColor = backgroundColor;
+  contentStyle.minWidth = Number(minWidth || 0);
+  contentStyle.minHeight = Number(minHeight || 0);
   return contentStyle as ContentStyleExplicit;
 };
 


### PR DESCRIPTION
## Description

Fixes (issue #)

Fixes this upstream issue: https://github.com/PedroBern/react-native-collapsible-tab-view/issues/335
Related: https://github.com/Shopify/flash-list/discussions/517

I'm not sure why other `contentContainerStyle` props are not explicitly allowed, but `minHeight` and `minWidth` seem like they should be.

I have confirmed that this fixes the upstream issue linked.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

Before:

https://user-images.githubusercontent.com/697707/233771319-5087ff0b-edd3-40a2-9d14-98c6cbb4f1b4.mp4



After:


https://github.com/user-attachments/assets/92404354-da5d-44c6-984b-d405898c174c


<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
