### PR TITLE
Fix incorrect rendering when StrictMode is enabled

### DIFF
--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -304,6 +304,12 @@ export class RecyclerViewManager<T> {
     return this.updateScrollOffset(this.getAbsoluteLastScrollOffset());
   }
 
+  restoreIfNeeded() {
+    if (this._isDisposed) {
+      this._isDisposed = false;
+    }
+  }
+
   dispose() {
     this._isDisposed = true;
     this.itemViewabilityManager.dispose();

--- a/src/recyclerview/hooks/useRecyclerViewManager.ts
+++ b/src/recyclerview/hooks/useRecyclerViewManager.ts
@@ -28,11 +28,13 @@ export const useRecyclerViewManager = <T>(props: RecyclerViewProps<T>) => {
   }, [data]);
 
   useEffect(() => {
+    recyclerViewManager.restoreIfNeeded();
+
     return () => {
       recyclerViewManager.dispose();
       velocityTracker.cleanUp();
     };
-    // needs to run only on unmount
+    // Used to perform cleanup on unmount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Description

Fixes (#1669)

This PR fixes the issue of flash-list not rendering items correctly when React StrictMode is on. 

When StrictMode is on, React runs setup and cleanup one extra time. Since `_isDisposed` flag in `recyclerViewManager` is not reset during setup, `RecyclerViewManager` incorrectly stays in disposed state after initialization. 

Fixes the issue by balancing the setup and cleanup calls in `useEffect` hook. 



<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

After wrapping the app in StrictMode component, rendering of items now works correctly. Example in fixture app:

![flash-list-fix](https://github.com/user-attachments/assets/159c6c45-d50b-443f-95e9-cbf25041d449)


