### PR TITLE
Disable startRendering from bottom when list is empty

### DIFF
--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -419,7 +419,8 @@ const RecyclerViewComponent = <T,>(
   }, [maintainVisibleContentPosition, shouldMaintainVisibleContentPosition]);
 
   const shouldRenderFromBottom =
-    maintainVisibleContentPosition?.startRenderingFromBottom ?? false;
+    recyclerViewManager.getDataLength() > 0 &&
+    (maintainVisibleContentPosition?.startRenderingFromBottom ?? false);
 
   // Calculate minimum height adjustment for bottom rendering
   const adjustmentMinHeight = recyclerViewManager.hasLayout()


### PR DESCRIPTION
## Description

resolves #1711 

Extra padding shouldn't be applied when the list is empty when using `startRenderingFromBottom`.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
