### PR TITLE
Disable offset corrections when animation is scheduled

### DIFF
--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -533,7 +533,7 @@ const RecyclerViewComponent = <T,>(
               applyInitialScrollIndex();
               checkBounds();
               recyclerViewManager.computeItemViewability();
-              recyclerViewManager.disableRecycling(false);
+              recyclerViewManager.animationOptimizationsEnabled = false;
             }}
             CellRendererComponent={CellRendererComponent}
             ItemSeparatorComponent={ItemSeparatorComponent}

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -31,9 +31,19 @@ export class RecyclerViewManager<T> {
   private itemViewabilityManager: ViewabilityManager<T>;
   private _isDisposed = false;
   private _isLayoutManagerDirty = false;
+  private _animationOptimizationsEnabled = false;
 
   public firstItemOffset = 0;
   public ignoreScrollEvents = false;
+
+  public get animationOptimizationsEnabled() {
+    return this._animationOptimizationsEnabled;
+  }
+
+  public set animationOptimizationsEnabled(value: boolean) {
+    this._animationOptimizationsEnabled = value;
+    this.renderStackManager.disableRecycling = value;
+  }
 
   public get isOffsetProjectionEnabled() {
     return this.engagedIndicesTracker.enableOffsetProjection;
@@ -117,10 +127,6 @@ export class RecyclerViewManager<T> {
 
   getIsFirstLayoutComplete() {
     return this.isFirstLayoutComplete;
-  }
-
-  disableRecycling(disable: boolean) {
-    this.renderStackManager.disableRecycling = disable;
   }
 
   getLayout(index: number) {

--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -167,7 +167,11 @@ export function useRecyclerViewController<T>(
           firstVisibleItemLayout.current = {
             ...recyclerViewManager.getLayout(currentIndexOfFirstVisibleItem),
           };
-          if (diff !== 0 && !pauseOffsetCorrection.current) {
+          if (
+            diff !== 0 &&
+            !pauseOffsetCorrection.current &&
+            !recyclerViewManager.animationOptimizationsEnabled
+          ) {
             // console.log("diff", diff, firstVisibleItemKey.current);
             if (PlatformConfig.supportsOffsetCorrection) {
               // console.log("scrollBy", diff);
@@ -543,7 +547,7 @@ export function useRecyclerViewController<T>(
        * Disables item recycling in preparation for layout animations.
        */
       prepareForLayoutAnimationRender: () => {
-        recyclerViewManager.disableRecycling(true);
+        recyclerViewManager.animationOptimizationsEnabled = true;
       },
     };
   }, [


### PR DESCRIPTION
## Description

Helps solve a common issue which happens when item inserted at position 0 (with animation) can cause the list to scroll due to maintainVisibleContentPosition.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
