### PR TITLE
Fix crash in StickyHeders on data change

### DIFF
--- a/src/recyclerview/components/StickyHeaders.tsx
+++ b/src/recyclerview/components/StickyHeaders.tsx
@@ -171,7 +171,7 @@ export const StickyHeaders = <TItem,>({
           transform: [{ translateY }],
         }}
       >
-        {currentStickyIndex !== -1 ? (
+        {currentStickyIndex !== -1 && currentStickyIndex < data.length ? (
           <ViewHolder
             index={currentStickyIndex}
             item={data[currentStickyIndex]}


### PR DESCRIPTION
## Description

Sticky headers were causing a crash when data was being removed from the list.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
