### PR TITLE
Fix web viewability with paging enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/flash-list",
-  "version": "2.0.0-rc.7",
+  "version": "2.0.0-rc.8",
   "keywords": [
     "react-native",
     "recyclerview",

--- a/src/recyclerview/utils/measureLayout.web.ts
+++ b/src/recyclerview/utils/measureLayout.web.ts
@@ -12,15 +12,13 @@ function getScrollOffsets(element: Element, stopAt: Element) {
   let scrollX = 0;
   let scrollY = 0;
   let currentElement: Element | null = element;
-  let depth = 0;
 
   // Only check up to 3 parent elements
-  while (currentElement && currentElement !== stopAt && depth < 3) {
+  while (currentElement && currentElement !== stopAt) {
     const htmlElement = currentElement as HTMLElement;
     scrollX += htmlElement.scrollLeft ?? 0;
     scrollY += htmlElement.scrollTop ?? 0;
     currentElement = currentElement.parentElement;
-    depth++;
   }
 
   return { scrollX, scrollY };


### PR DESCRIPTION
## Description

Get rid of depth in first item offset calculation on web as it breaks paging enabled viewability tracking

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
