### PR TITLE
Fix list auto scroll to bottom with threshold -1

### DIFF
--- a/src/recyclerview/hooks/useBoundDetection.ts
+++ b/src/recyclerview/hooks/useBoundDetection.ts
@@ -94,7 +94,7 @@ export function useBoundDetection<T>(
       }
 
       // Handle auto-scrolling to bottom for vertical lists
-      if (!isHorizontal) {
+      if (!isHorizontal && autoscrollToBottomThreshold >= 0) {
         const autoscrollToBottomThresholdDistance =
           autoscrollToBottomThreshold * visibleLength;
 


### PR DESCRIPTION
## Description
When I reload my list, the content scrolls to bottom even though I'm not setting `autoscrollToBottomThreshold`. If I set it to -1, the problem still happens, because it's the same value the code coalesces to for undefined.

Fixes https://github.com/Shopify/flash-list/issues/1736

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
