### PR TITLE
Add LayoutCommitObserver

### DIFF
--- a/documentation/docs/fundamentals/layout-commit-observer.md
+++ b/documentation/docs/fundamentals/layout-commit-observer.md
@@ -1,0 +1,54 @@
+---
+id: layout-commit-observer
+title: Layout Commit Observer
+---
+
+# Layout Commit Observer
+
+The `LayoutCommitObserver` is a utility component that helps you track when all FlashList components in your component tree have completed their initial layout. This is particularly useful for coordinating complex UI behaviors that depend on list rendering completion. Doing your own `setState` in this callback will block paint till your state change is ready to be committed.
+
+## Overview
+
+When working with multiple FlashList components or when you need to perform actions after a FlashList has finished its initial render, the LayoutCommitObserver provides a clean way to observe and react to these layout events.
+
+## When to Use
+
+- Measure size of views after all internal lists have rendered
+- Don't have access to FlashList for example, your component just accepts `children` prop.
+
+## When not to use
+
+- If you don't need to block paint then using the `onLoad` callback is a better approach.
+- If you only have one FlashList and have access to it. `onCommitLayoutEffect` is a prop on FlashList too.
+
+## Basic Usage
+
+Wrap your component tree containing FlashLists with LayoutCommitObserver:
+
+```tsx
+import { LayoutCommitObserver } from "@shopify/flash-list";
+
+function MyScreen() {
+  const handleLayoutComplete = () => {
+    console.log("All FlashLists have completed their initial layout!");
+    // Perform any post-layout actions here
+  };
+
+  return (
+    <LayoutCommitObserver onCommitLayoutEffect={handleLayoutComplete}>
+      <View>
+        <FlashList
+          data={data1}
+          renderItem={renderItem1}
+          estimatedItemSize={50}
+        />
+        <FlashList
+          data={data2}
+          renderItem={renderItem2}
+          estimatedItemSize={100}
+        />
+      </View>
+    </LayoutCommitObserver>
+  );
+}
+```

--- a/fixture/react-native/ios/Podfile.lock
+++ b/fixture/react-native/ios/Podfile.lock
@@ -1775,7 +1775,7 @@ PODS:
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageWebPCoder (~> 0.14)
     - Yoga
-  - RNFlashList (2.0.0-rc.1):
+  - RNFlashList (2.0.0-rc.10):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2331,7 +2331,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 025b1e9baf2a32b7466b00c20dd5b1b8c6388d07
   ReactCommon: ff9f7add7560c9f15cf6e9d0320f9ad45b696062
   RNFastImage: 2990d3d7033b95119354cc27f383010c7d1e2165
-  RNFlashList: 31c767ec71f73679dd3804149ff1111259b0c872
+  RNFlashList: 1c295214ba885a4b5053daa19263cacf4602986e
   RNGestureHandler: 8ff2b1434b0ff8bab28c8242a656fb842990bbc8
   RNReanimated: f52ccd5ceea2bae48d7421eec89b3f0c10d7b642
   RNScreens: b09235ac2de51cc1c3dbae34ad7b15a604745983

--- a/src/__tests__/LayoutCommitObserver.test.tsx
+++ b/src/__tests__/LayoutCommitObserver.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render } from "@quilted/react-testing";
+
+import { RecyclerView } from "../recyclerview/RecyclerView";
+import { useFlashListContext } from "../recyclerview/RecyclerViewContextProvider";
+import { LayoutCommitObserver } from "../recyclerview/LayoutCommitObserver";
+
+describe("LayoutCommitObserver", () => {
+  it("should not alter ref captured by child", () => {
+    const ChildComponent = () => {
+      const context = useFlashListContext();
+      expect(context?.getRef()?.props.testID).toBe("child");
+      expect(context?.getParentRef()?.props.testID).toBe("parent");
+      expect(context?.getScrollViewRef()?.props.testID).toBe("child");
+      expect(context?.getParentScrollViewRef()?.props.testID).toBe("parent");
+
+      return null;
+    };
+
+    let commitLayoutEffectCount = 0;
+
+    const content = (
+      <RecyclerView
+        testID="parent"
+        data={[1]}
+        renderItem={() => (
+          <LayoutCommitObserver
+            onCommitLayoutEffect={() => {
+              commitLayoutEffectCount++;
+            }}
+          >
+            <RecyclerView
+              testID="child"
+              data={[1]}
+              renderItem={() => (
+                <LayoutCommitObserver
+                  onCommitLayoutEffect={() => {
+                    commitLayoutEffectCount++;
+                  }}
+                >
+                  <LayoutCommitObserver
+                    onCommitLayoutEffect={() => {
+                      commitLayoutEffectCount++;
+                    }}
+                  >
+                    <ChildComponent />
+                  </LayoutCommitObserver>
+                </LayoutCommitObserver>
+              )}
+            />
+          </LayoutCommitObserver>
+        )}
+      />
+    );
+
+    render(content);
+
+    expect(commitLayoutEffectCount).toBe(3);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ export { default as CellContainer } from "./native/cell-container/CellContainer"
 export { RecyclerView } from "./recyclerview/RecyclerView";
 export { RecyclerViewProps } from "./recyclerview/RecyclerViewProps";
 export { useFlashListContext } from "./recyclerview/RecyclerViewContextProvider";
+export {
+  LayoutCommitObserver,
+  LayoutCommitObserverProps,
+} from "./recyclerview/LayoutCommitObserver";
 
 // @ts-ignore - This is ignored by TypeScript but will be present in the compiled JS
 // In the compiled JS, this will override the previous FlashList export with a conditional one

--- a/src/recyclerview/LayoutCommitObserver.tsx
+++ b/src/recyclerview/LayoutCommitObserver.tsx
@@ -1,0 +1,74 @@
+import React, { useLayoutEffect, useMemo, useRef } from "react";
+
+import {
+  RecyclerViewContext,
+  RecyclerViewContextProvider,
+  useRecyclerViewContext,
+} from "./RecyclerViewContextProvider";
+import { useLayoutState } from "./hooks/useLayoutState";
+
+export interface LayoutCommitObserverProps {
+  children: React.ReactNode;
+  onCommitLayoutEffect?: () => void;
+}
+
+/**
+ * LayoutCommitObserver can be used to observe when FlashList commits a layout.
+ * It is useful when your component has one or more FlashLists somewhere down the tree.
+ * LayoutCommitObserver will trigger `onCommitLayoutEffect` when all of the FlashLists in the tree have finished their first commit.
+ */
+export const LayoutCommitObserver = React.memo(
+  (props: LayoutCommitObserverProps) => {
+    const { children, onCommitLayoutEffect } = props;
+    const parentRecyclerViewContext = useRecyclerViewContext();
+    const [_, setRenderId] = useLayoutState(0);
+    const pendingChildIds = useRef<Set<string>>(new Set()).current;
+
+    useLayoutEffect(() => {
+      if (pendingChildIds.size > 0) {
+        return;
+      }
+      onCommitLayoutEffect?.();
+    });
+
+    // Create context for child components
+    const recyclerViewContext: RecyclerViewContext<unknown> = useMemo(() => {
+      return {
+        layout: () => {
+          setRenderId((prev) => prev + 1);
+        },
+        getRef: () => {
+          return parentRecyclerViewContext?.getRef() ?? null;
+        },
+        getParentRef: () => {
+          return parentRecyclerViewContext?.getParentRef() ?? null;
+        },
+        getParentScrollViewRef: () => {
+          return parentRecyclerViewContext?.getParentScrollViewRef() ?? null;
+        },
+        getScrollViewRef: () => {
+          return parentRecyclerViewContext?.getScrollViewRef() ?? null;
+        },
+        markChildLayoutAsPending: (id: string) => {
+          parentRecyclerViewContext?.markChildLayoutAsPending(id);
+          pendingChildIds.add(id);
+        },
+        unmarkChildLayoutAsPending: (id: string) => {
+          parentRecyclerViewContext?.unmarkChildLayoutAsPending(id);
+          if (pendingChildIds.has(id)) {
+            pendingChildIds.delete(id);
+            recyclerViewContext.layout();
+          }
+        },
+      };
+    }, [parentRecyclerViewContext, pendingChildIds, setRenderId]);
+
+    return (
+      <RecyclerViewContextProvider value={recyclerViewContext}>
+        {children}
+      </RecyclerViewContextProvider>
+    );
+  }
+);
+
+LayoutCommitObserver.displayName = "LayoutCommitObserver";


### PR DESCRIPTION
## Description

Add `LayoutCommitObserver` which can help detect when all FlashLists down the tree have finished rendering. Can be very useful in cases where size needs to be measured before lists paint.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
