### PR TITLE
Fix footer flicker while scrolling to end.

### DIFF
--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -279,10 +279,13 @@ export function useRecyclerViewController<T>(
       scrollToEnd: async ({ animated }: ScrollToEdgeParams = {}) => {
         const { data } = recyclerViewManager.props;
         if (data && data.length > 0) {
-          await handlerMethods.scrollToIndex({
-            index: data.length - 1,
-            animated,
-          });
+          const lastIndex = data.length - 1;
+          if (!recyclerViewManager.getEngagedIndices().includes(lastIndex)) {
+            await handlerMethods.scrollToIndex({
+              index: lastIndex,
+              animated,
+            });
+          }
         }
         setTimeout(() => {
           scrollViewRef.current!.scrollToEnd({ animated });


### PR DESCRIPTION
## Description

resolves #1772 

scrollToIndex call doesn't account footer size so we need to ensure that if last index is already visible, we don't call it again.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
