### PR TITLE
Add warning when keyExtractor is not defined with maintainVisibleContentPosition

### DIFF
--- a/src/__tests__/RecyclerViewManager.test.ts
+++ b/src/__tests__/RecyclerViewManager.test.ts
@@ -1,0 +1,86 @@
+import { RecyclerViewManager } from "../recyclerview/RecyclerViewManager";
+import { WarningMessages } from "../errors/WarningMessages";
+
+describe("RecyclerViewManager", () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe("keyExtractor warning with maintainVisibleContentPosition", () => {
+    const createMockProps = (overrides = {}) => ({
+      data: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      renderItem: jest.fn(),
+      stickyHeaderIndices: [],
+      getItemType: jest.fn(() => "default"),
+      viewabilityConfig: null,
+      viewabilityConfigCallbackPairs: [],
+      onVisibleItemsChanged: undefined,
+      onViewableItemsChanged: undefined,
+      horizontal: false,
+      inverted: false,
+      keyExtractor: undefined,
+      extraData: undefined,
+      onStartReached: undefined,
+      onStartReachedThreshold: undefined,
+      onMomentumScrollBegin: undefined,
+      onMomentumScrollEnd: undefined,
+      onScrollBeginDrag: undefined,
+      onScrollEndDrag: undefined,
+      onScroll: undefined,
+      maxItemsInRecyclePool: undefined,
+      ...overrides,
+    });
+
+    it("should warn when onStartReached is defined but keyExtractor is not", () => {
+      const props = createMockProps({
+        onStartReached: jest.fn(),
+        keyExtractor: undefined,
+      });
+
+      new RecyclerViewManager(props as any);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        WarningMessages.keyExtractorNotDefinedForMVCP
+      );
+    });
+
+    it("should not warn when both onStartReached and keyExtractor are defined", () => {
+      const props = createMockProps({
+        onStartReached: jest.fn(),
+        keyExtractor: (item: any) => item.id.toString(),
+      });
+
+      new RecyclerViewManager(props as any);
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not warn when onStartReached is not defined", () => {
+      const props = createMockProps({
+        onStartReached: undefined,
+        keyExtractor: undefined,
+      });
+
+      new RecyclerViewManager(props as any);
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not warn when onStartReached is not defined but keyExtractor is", () => {
+      const props = createMockProps({
+        onStartReached: undefined,
+        keyExtractor: (item: any) => item.id.toString(),
+      });
+
+      new RecyclerViewManager(props as any);
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/RecyclerViewManager.test.ts
+++ b/src/__tests__/RecyclerViewManager.test.ts
@@ -1,5 +1,6 @@
 import { RecyclerViewManager } from "../recyclerview/RecyclerViewManager";
 import { WarningMessages } from "../errors/WarningMessages";
+import { FlashListProps } from "../FlashListProps";
 
 describe("RecyclerViewManager", () => {
   let consoleWarnSpy: jest.SpyInstance;
@@ -13,29 +14,16 @@ describe("RecyclerViewManager", () => {
   });
 
   describe("keyExtractor warning with maintainVisibleContentPosition", () => {
-    const createMockProps = (overrides = {}) => ({
-      data: [{ id: 1 }, { id: 2 }, { id: 3 }],
-      renderItem: jest.fn(),
-      stickyHeaderIndices: [],
-      getItemType: jest.fn(() => "default"),
-      viewabilityConfig: null,
-      viewabilityConfigCallbackPairs: [],
-      onVisibleItemsChanged: undefined,
-      onViewableItemsChanged: undefined,
-      horizontal: false,
-      inverted: false,
-      keyExtractor: undefined,
-      extraData: undefined,
-      onStartReached: undefined,
-      onStartReachedThreshold: undefined,
-      onMomentumScrollBegin: undefined,
-      onMomentumScrollEnd: undefined,
-      onScrollBeginDrag: undefined,
-      onScrollEndDrag: undefined,
-      onScroll: undefined,
-      maxItemsInRecyclePool: undefined,
-      ...overrides,
-    });
+    const createMockProps = (overrides = {}) =>
+      ({
+        data: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        renderItem: jest.fn(),
+        ...overrides,
+      } as FlashListProps<unknown>);
+
+    const createManager = (props: FlashListProps<unknown>) => {
+      return new RecyclerViewManager(props);
+    };
 
     it("should warn when onStartReached is defined but keyExtractor is not", () => {
       const props = createMockProps({
@@ -43,7 +31,7 @@ describe("RecyclerViewManager", () => {
         keyExtractor: undefined,
       });
 
-      new RecyclerViewManager(props as any);
+      createManager(props);
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         WarningMessages.keyExtractorNotDefinedForMVCP
@@ -56,7 +44,7 @@ describe("RecyclerViewManager", () => {
         keyExtractor: (item: any) => item.id.toString(),
       });
 
-      new RecyclerViewManager(props as any);
+      createManager(props);
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
@@ -67,7 +55,7 @@ describe("RecyclerViewManager", () => {
         keyExtractor: undefined,
       });
 
-      new RecyclerViewManager(props as any);
+      createManager(props);
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
@@ -78,7 +66,7 @@ describe("RecyclerViewManager", () => {
         keyExtractor: (item: any) => item.id.toString(),
       });
 
-      new RecyclerViewManager(props as any);
+      createManager(props);
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });

--- a/src/errors/WarningMessages.ts
+++ b/src/errors/WarningMessages.ts
@@ -1,6 +1,8 @@
 export const WarningMessages = {
   keyExtractorNotDefinedForAnimation:
     "keyExtractor is not defined. This might cause the animations to not work as expected.",
+  keyExtractorNotDefinedForMVCP:
+    "keyExtractor is not defined, maintainVisibleContentPosition may not work as expected.",
   exceededMaxRendersWithoutCommit:
     "Exceeded max renders without commit. This might mean that you have duplicate keys in your keyExtractor output or your list is nested in a ScrollView causing a lot of items to render at once. " +
     "If it's none of those and is causing a real issue or error, consider reporing this on FlashList Github",

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -1,4 +1,5 @@
 import { ErrorMessages } from "../errors/ErrorMessages";
+import { WarningMessages } from "../errors/WarningMessages";
 
 import ViewabilityManager from "./viewability/ViewabilityManager";
 import { ConsecutiveNumbers } from "./helpers/ConsecutiveNumbers";
@@ -19,7 +20,6 @@ import {
   Velocity,
 } from "./helpers/EngagedIndicesTracker";
 import { RenderStackManager } from "./RenderStackManager";
-import { WarningMessages } from "../errors/WarningMessages";
 // Abstracts layout manager, render stack manager and viewability manager and generates render stack (progressively on load)
 export class RecyclerViewManager<T> {
   private initialDrawBatchSize = 2;

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -19,6 +19,7 @@ import {
   Velocity,
 } from "./helpers/EngagedIndicesTracker";
 import { RenderStackManager } from "./RenderStackManager";
+import { WarningMessages } from "../errors/WarningMessages";
 // Abstracts layout manager, render stack manager and viewability manager and generates render stack (progressively on load)
 export class RecyclerViewManager<T> {
   private initialDrawBatchSize = 2;
@@ -69,6 +70,7 @@ export class RecyclerViewManager<T> {
       props.maxItemsInRecyclePool
     );
     this.itemViewabilityManager = new ViewabilityManager<T>(this as any);
+    this.checkPropsAndWarn();
   }
 
   // updates render stack based on the engaged indices which are sorted. Recycles unused keys.
@@ -445,5 +447,11 @@ export class RecyclerViewManager<T> {
       this.numColumns,
       this.propsRef.extraData
     );
+  }
+
+  private checkPropsAndWarn() {
+    if (this.propsRef.onStartReached && !this.propsRef.keyExtractor) {
+      console.warn(WarningMessages.keyExtractorNotDefinedForMVCP);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Added a new warning message when `keyExtractor` is not defined while using `maintainVisibleContentPosition`
- Implemented check in RecyclerViewManager to detect this scenario and warn developers
- Helps prevent issues with content position maintenance in chat-like interfaces

## Context
When using `maintainVisibleContentPosition` (triggered through `onStartReached`), having a proper `keyExtractor` is crucial for the list to correctly track and maintain the position of visible items. Without it, the feature may not work as expected, especially when new items are added to the list.

## Changes
- Added new warning message in `WarningMessages.ts`
- Implemented prop validation in `RecyclerViewManager` constructor
- Warning triggers when `onStartReached` is defined but `keyExtractor` is not

## Test plan
- [x] Warning appears in console when using `maintainVisibleContentPosition` without `keyExtractor`
- [x] No warning when both are properly defined
- [x] No warning when neither is used
- [x] Existing functionality remains unchanged