### PR TITLE
Apply initialScrollOffset to it initial scroll position

### DIFF
--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -167,6 +167,12 @@ export interface FlashListProps<TItem>
   initialScrollIndex?: number | null | undefined;
 
   /**
+   * Offset to apply to initial scroll position as defined by initialScrollIndex.
+   * Ignored if initialScrollOffset is not set.
+   */
+  initialScrollOffset?: { x: number; y: number } | null | undefined;
+
+  /**
    * Used to extract a unique key for a given item at the specified index.
    * Key is used for optimizing performance. Defining `keyExtractor` is also necessary
    * when doing [layout animations](https://shopify.github.io/flash-list/docs/guides/layout-animation)

--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -564,7 +564,7 @@ export function useRecyclerViewController<T>(
   ]);
 
   const applyInitialScrollIndex = useCallback(() => {
-    const { horizontal, data } = recyclerViewManager.props;
+    const { horizontal, data, initialScrollOffset } = recyclerViewManager.props;
 
     const initialScrollIndex =
       recyclerViewManager.getInitialScrollIndex() ?? -1;
@@ -583,9 +583,13 @@ export function useRecyclerViewController<T>(
 
       pauseOffsetCorrection.current = true;
 
+      const additionalOffsetX = initialScrollOffset?.x ?? 0;
+      const additionalOffsetY = initialScrollOffset?.y ?? 0;
       const offset = horizontal
-        ? recyclerViewManager.getLayout(initialScrollIndex).x
-        : recyclerViewManager.getLayout(initialScrollIndex).y;
+        ? recyclerViewManager.getLayout(initialScrollIndex).x +
+          additionalOffsetX
+        : recyclerViewManager.getLayout(initialScrollIndex).y +
+          additionalOffsetY;
       handlerMethods.scrollToOffset({
         offset,
         animated: false,


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/flash-list/discussions/700

Adds a new property `initialScrollOffset` which allows applying an offset to `initialScrollIndex`.