### PR TITLE
Fix infinite loop when a lot of horizontal lists are inside a vertical one

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -190,7 +190,6 @@ export type ContentStyle = Pick<
 
 You can use `contentContainerStyle` to apply padding that will be applied to the whole content itself. For example, you can apply this padding, so that all of your items have leading and trailing space.
 
-
 ### `drawDistance`
 
 ```tsx
@@ -349,7 +348,7 @@ How far from the end (in units of visible length of the list) the bottom edge of
 onLoad: (info: { elapsedTimeInMs: number }) => void;
 ```
 
-This event is raised once the list has drawn items on the screen. It also reports elapsedTimeInMs which is the time it took to draw the items. This is required because FlashList doesn't render items in the first cycle. Items are drawn after it measures itself at the end of first render. If you're using ListEmptyComponent, this event is raised as soon as ListEmptyComponent is rendered.
+This event is raised once the list has drawn items on the screen. It also reports elapsedTimeInMs which is the time it took to draw the items. This is required because FlashList doesn't render items in the first cycle. Items are drawn after it measures itself at the end of first render. Please note that the event is not fired if ListEmptyComponent is rendered.
 
 ### `onRefresh`
 

--- a/fixture/react-native/src/ExamplesScreen.tsx
+++ b/fixture/react-native/src/ExamplesScreen.tsx
@@ -91,6 +91,10 @@ export const ExamplesScreen = () => {
       title: "Showcase App",
       destination: "ShowcaseApp",
     },
+    {
+      title: "Lot of Items",
+      destination: "LotOfItems",
+    },
   ];
   return (
     <>

--- a/fixture/react-native/src/NavigationTree.tsx
+++ b/fixture/react-native/src/NavigationTree.tsx
@@ -28,6 +28,7 @@ import MovieList from "./MovieList";
 import Carousel from "./Carousel";
 import { LayoutOptions } from "./LayoutOptions";
 import ShowcaseApp from "./ShowcaseApp";
+import LotOfItems from "./lot-of-items/LotOfItems";
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -97,6 +98,11 @@ const NavigationTree = () => {
             name="ShowcaseApp"
             component={ShowcaseApp}
             options={{ title: "Showcase App" }}
+          />
+          <Stack.Screen
+            name="LotOfItems"
+            component={LotOfItems}
+            options={{ title: "Lot of Items" }}
           />
         </Stack.Group>
         <Stack.Screen name="Masonry" component={Masonry} />

--- a/fixture/react-native/src/constants.ts
+++ b/fixture/react-native/src/constants.ts
@@ -32,4 +32,5 @@ export type RootStackParamList = {
   Carousel: undefined;
   LayoutOptions: undefined;
   ShowcaseApp: undefined;
+  LotOfItems: undefined;
 };

--- a/fixture/react-native/src/lot-of-items/LotOfItems.tsx
+++ b/fixture/react-native/src/lot-of-items/LotOfItems.tsx
@@ -1,0 +1,38 @@
+import { View, StyleSheet } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+import React from "react";
+
+import LotOfItemsHorizontalList from "./LotOfItemsHorizontalList";
+
+interface Item {
+  id: number;
+  title: string;
+}
+
+const DATA = [...Array(100).keys()].map((i) => {
+  return { id: i, title: `Bloc ${i}` };
+});
+
+function ItemList({ item }: { item: Item }) {
+  return (
+    <View>
+      <LotOfItemsHorizontalList />
+    </View>
+  );
+}
+
+const renderItem = ({ item }: { item: Item }) => {
+  return <ItemList item={item} />;
+};
+
+export default function Reminders() {
+  return (
+    <FlashList data={DATA} renderItem={renderItem} style={styles.container} />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: "#ecf0f1",
+  },
+});

--- a/fixture/react-native/src/lot-of-items/LotOfItemsHorizontalList.tsx
+++ b/fixture/react-native/src/lot-of-items/LotOfItemsHorizontalList.tsx
@@ -1,0 +1,39 @@
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+import React from "react";
+
+interface Item {
+  id: number;
+  title: string;
+}
+
+const DATA = [...Array(30).keys()].map((i) => {
+  return { id: i, title: `Item ${i}` };
+});
+
+function Item({ item }: { item: Item }) {
+  return (
+    <Pressable>
+      {({ pressed }) => (
+        <View style={styles.item}>
+          <Text>{item.title}</Text>
+          {pressed ? <Text>pressed</Text> : null}
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const renderItem = ({ item }: { item: Item }) => {
+  return <Item item={item} />;
+};
+
+export default function LotOfItemsHorizontalList() {
+  return <FlashList data={DATA} horizontal renderItem={renderItem} />;
+}
+
+const styles = StyleSheet.create({
+  item: {
+    width: 50,
+  },
+});

--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -227,6 +227,17 @@ const RecyclerViewComponent = <T,>(
       viewHolderCollectionRef.current?.commitLayout();
       applyOffsetCorrection();
     }
+
+    if (
+      horizontal &&
+      recyclerViewManager.hasLayout() &&
+      recyclerViewManager.getWindowSize().height > 0
+    ) {
+      // We want the parent FlashList to continue rendering the next batch of items as soon as height is available.
+      // Waiting for each horizontal list to finish might cause too many setState calls.
+      // This will help avoid "Maximum update depth exceeded" error.
+      parentRecyclerViewContext?.unmarkChildLayoutAsPending(recyclerViewId);
+    }
   });
 
   /**

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -38,6 +38,7 @@ export class RecyclerViewManager<T> {
 
   public firstItemOffset = 0;
   public ignoreScrollEvents = false;
+  public isFirstPaintOnUiComplete = false;
 
   public get animationOptimizationsEnabled() {
     return this._animationOptimizationsEnabled;
@@ -263,6 +264,9 @@ export class RecyclerViewManager<T> {
       return true;
     }
     if (this.hasRenderedProgressively) {
+      if (!this.isFirstPaintOnUiComplete) {
+        return false;
+      }
       return this.recomputeEngagedIndices() !== undefined;
     } else {
       this.renderProgressively();

--- a/src/recyclerview/hooks/useOnLoad.ts
+++ b/src/recyclerview/hooks/useOnLoad.ts
@@ -48,6 +48,7 @@ export const useOnListLoad = <T>(
     // console.log("----------> dataCollector", dataCollectorString);
     // console.log("----------> FlashList v2 load in", `${elapsedTimeInMs} ms`);
     requestAnimationFrame(() => {
+      recyclerViewManager.isFirstPaintOnUiComplete = true;
       onLoad?.({ elapsedTimeInMs });
       setIsLoaded(true);
     });


### PR DESCRIPTION
## Title
Reduce setState churn for nested lists and clarify onLoad docs

## Summary
- Reduce unnecessary `setState` calls when lists are nested to improve performance and prevent render loops in nested/horizontal configurations.
- Clarify `onLoad` callback behavior and usage in docs.
- Add a new sample to test

## Breaking Changes
- None expected.
