### PR TITLE
Remove test files from the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   "files": [
     "dist",
     "src",
-    "jestSetup.js"
+    "jestSetup.js",
+    "!__tests__"
   ],
   "dependencies": {
     "tslib": "2.8.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts?(x)"]
+  "exclude": ["node_modules", "src/__tests__", "**/*.test.ts?(x)"]
 }


### PR DESCRIPTION
## Description

While working on adding a new metadata information to the React Native Directory, and analysing the results, I have spotted that `@shopify/flash-list` published package includes test files, which increase significantly the final bundle size, see:
* https://www.npmjs.com/package/@shopify/flash-list?activeTab=code

To avoid that, I have altered the `files` array in `package.json` file, and added exclusion for the `__tests__` directories.

Since tests are only run [from the `src` directory](https://github.com/Shopify/flash-list/blob/47db753e4e2a83fa2eba583bed254314a5790076/jest.config.js#L7-L7), I have also excluded the test directory from the TypeScript config, which speed up the build time slightly on my machine (0.2-0.3s).

## Test plan

I have run the `npm pack --dry-run` command before and after the changes, and make sure that tests file are no longer a part of the final bundle. 

Results are as follows, before the change:

```
npm notice filename: shopify-flash-list-2.0.4-alpha.1.tgz
npm notice package size: 229.9 kB
npm notice unpacked size: 1.2 MB
```

After excluding test files:

```
npm notice filename: shopify-flash-list-2.0.4-alpha.1.tgz
npm notice package size: 185.8 kB
npm notice unpacked size: 841.7 kB
```
