### PR TITLE
Update TypeScript compilation target to ES2018

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,5 @@
     "src",
     "jestSetup.js",
     "!__tests__"
-  ],
-  "dependencies": {
-    "tslib": "2.8.1"
-  }
+  ]
 }

--- a/shared/tsconfig.base.json
+++ b/shared/tsconfig.base.json
@@ -6,8 +6,8 @@
     "declarationMap": true,
     "pretty": true,
     "moduleResolution": "node",
-    "target": "es5",
-    "downlevelIteration": true,
+    "target": "es2018",
+    "module": "ES2015",
     "esModuleInterop": true,
     "jsx": "react",
     "strictNullChecks": true,
@@ -16,17 +16,8 @@
     "noEmitOnError": false,
     "experimentalDecorators": true,
     "noUnusedLocals": true,
-    "importHelpers": true,
     "skipLibCheck": true,
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "es2015",
-      "es2016",
-      "es2017",
-      "es2018",
-      "esnext.asynciterable"
-    ],
+    "lib": ["dom", "es2018", "esnext.asynciterable"],
     "typeRoots": ["../node_modules/@types"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7065,15 +7065,15 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.8.1, tslib@^2, tslib@^2.0.1, tslib@^2.0.3:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2, tslib@^2.0.1, tslib@^2.0.3:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.0.1:
   version "2.0.3"


### PR DESCRIPTION
## Summary
- Updated TypeScript compilation target from ES5 to ES2018
- Removed tslib dependency as it's no longer needed with ES2018 target
- Simplified lib configuration in tsconfig.base.json

## Test plan
- [x] Run build process to ensure successful compilation
- [x] Verify that tests pass
- [x] Check that the package works correctly in consuming applications
