### PR TITLE
Fix crash in scrollToEnd

### DIFF
--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -289,7 +289,7 @@ export function useRecyclerViewController<T>(
           }
         }
         setTimeout(() => {
-          scrollViewRef.current!.scrollToEnd({ animated });
+          scrollViewRef.current?.scrollToEnd({ animated });
         }, 0);
       },
 


### PR DESCRIPTION
## Description

In rare cases where the list unmounts just after a scrollToEnd, you get an unhandled `TypeError: Cannot read property 'scrollToEnd' of null` coming from this line:
```
setTimeout(function () {
    scrollViewRef.current.scrollToEnd({ animated: animated });
}, 0);
```
It might be a race condition with the `setTimeout`.

## Reviewers’ hat-rack :tophat:

Replacing `current!.scrollToEnd` with `current?.scrollToEnd` has no other impact since it's a side effect.