### PR TITLE
fix: prevent NPE in RecyclerView controller when ref is undefined

### DIFF
--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -289,7 +289,7 @@ export function useRecyclerViewController<T>(
           }
         }
         setTimeout(() => {
-          scrollViewRef.current!.scrollToEnd({ animated });
+          scrollViewRef.current?.scrollToEnd({ animated });
         }, 0);
       },
 


### PR DESCRIPTION
This fixes a potential null-pointer access inside useRecyclerViewController when the recycler ref can be temporarily undefined during layout or unmount transitions.\n\n- Adds a guard to avoid accessing properties when the ref is not yet set\n- Prevents crash observed in certain detachment sequences\n\nTest Plan:\n- Reproduced scenario in fixture app by rapidly mounting/unmounting list and navigating between screens\n- Verified no crashes and expected behavior of recycling logic\n\nChangelog:\n- [Fix] Safeguard against NPE in RecyclerView controller\n