### PR TITLE
Fix onStartReached detection

### DIFF
--- a/src/recyclerview/hooks/useBoundDetection.ts
+++ b/src/recyclerview/hooks/useBoundDetection.ts
@@ -104,8 +104,9 @@ export function useBoundDetection<T>(
       if (onStartReached) {
         const onStartReachedThreshold = onStartReachedThresholdProp ?? 0.2;
         const startThresholdDistance = onStartReachedThreshold * visibleLength;
+        const startBaseline = Math.max(0, recyclerViewManager.firstItemOffset);
 
-        const isNearStart = lastScrollOffset <= startThresholdDistance;
+        const isNearStart = lastScrollOffset <= startBaseline + startThresholdDistance;
 
         if (isNearStart && !pendingStartReached.current) {
           pendingStartReached.current = true;
@@ -146,9 +147,10 @@ export function useBoundDetection<T>(
     }
   }, [requestAnimationFrame, scrollViewRef, recyclerViewManager]);
 
-  // Reset end reached state when data changes
+  // Reset start/end reached state when data changes
   useMemo(() => {
     pendingEndReached.current = false;
+    pendingStartReached.current = false;
     // needs to run only when data changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);


### PR DESCRIPTION
## Description

When scrolling up with `onStartReached` `useBoundDetection` does not properly check scroll position while scrolling up. This resulted in `onStartReached` only firing when reaching the very top of the list and also firing while near top of the list and scrolling down. It was missing `firstItemOffset` in the calculation and missing `pendingStartReached.current = false` on data changes.

Fixes (issue #) https://github.com/Shopify/flash-list/issues/1872

Likely fixes 

[#1915
](https://github.com/Shopify/flash-list/issues/1915)
https://github.com/Shopify/flash-list/issues/1844
https://github.com/Shopify/flash-list/issues/1864


## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
