### PR TITLE
docs: remove reference to legacy contentContainerStyle prop

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -170,26 +170,6 @@ Styling for internal View for `ListHeaderComponent`.
 ListHeaderComponentStyle?: StyleProp<ViewStyle>;
 ```
 
-### `contentContainerStyle`
-
-```tsx
-contentContainerStyle?: ContentStyle;
-
-export type ContentStyle = Pick<
-  ViewStyle,
-  | "backgroundColor"
-  | "paddingTop"
-  | "paddingLeft"
-  | "paddingRight"
-  | "paddingBottom"
-  | "padding"
-  | "paddingVertical"
-  | "paddingHorizontal"
->;
-```
-
-You can use `contentContainerStyle` to apply padding that will be applied to the whole content itself. For example, you can apply this padding, so that all of your items have leading and trailing space.
-
 ### `drawDistance`
 
 ```tsx


### PR DESCRIPTION
Previously FlashList had a contentContainerStyle prop

https://github.com/Shopify/flash-list/blob/v1.x/src/FlashListProps.ts

But it's removed now

https://github.com/Shopify/flash-list/blob/main/src/FlashListProps.ts

... so this commit updates the documentation accordingly