### PR TITLE
fix: sticky header apprearance in flashlist v2

### DIFF
--- a/src/recyclerview/components/StickyHeaders.tsx
+++ b/src/recyclerview/components/StickyHeaders.tsx
@@ -92,7 +92,7 @@ export const StickyHeaders = <TItem,>({
     const currentIndexInArray = findCurrentStickyIndex(
       sortedIndices,
       adjustedScrollOffset,
-      (index) => recyclerViewManager.getLayout(index).y
+      (index) => recyclerViewManager.getLayout(index).y - recyclerViewManager.firstItemOffset
     );
 
     const newStickyIndex = sortedIndices[currentIndexInArray] ?? -1;
@@ -106,7 +106,7 @@ export const StickyHeaders = <TItem,>({
     const newNextStickyY =
       newNextStickyIndex === -1
         ? Number.MAX_SAFE_INTEGER
-        : (recyclerViewManager.tryGetLayout(newNextStickyIndex)?.y ?? 0) +
+        : (recyclerViewManager.tryGetLayout(newNextStickyIndex)?.y ?? 0) -
           recyclerViewManager.firstItemOffset;
     const newCurrentStickyHeight =
       recyclerViewManager.tryGetLayout(newStickyIndex)?.height ?? 0;


### PR DESCRIPTION
# Fix: Sticky Headers Appear Before Reaching Top of List

## 🐛 Problem

Sticky headers in FlashList appear **before** the header items actually reach the top of the viewport, causing a jarring visual effect where both the original header and the sticky header overlay are visible simultaneously.

This issue occurs when:
- Using `stickyHeaderIndices` prop
- List has non-zero `firstItemOffset` (e.g., padding, header components, or margin)

## 🔍 Root Cause Analysis

The bug is caused by **inconsistent coordinate system handling** in `src/recyclerview/components/StickyHeaders.tsx`:

### Current Implementation (Buggy):

**Line 95** - Binary search for current sticky index:
```typescript
(index) => recyclerViewManager.getLayout(index).y
```
Uses item Y position **without** `firstItemOffset` adjustment.

**Lines 109-110** - Calculate next sticky header position:
```typescript
: (recyclerViewManager.tryGetLayout(newNextStickyIndex)?.y ?? 0) +
  recyclerViewManager.firstItemOffset;
```
**Adds** `firstItemOffset` to item Y position.

### The Issue:
- The binary search compares scroll offset against raw item Y positions
- The push calculation adds `firstItemOffset` to item Y positions
- These two calculations use **different coordinate systems**
- Result: Binary search finds headers "too early" relative to when they should actually stick

## ✅ Solution

Normalize all Y position calculations by **subtracting** `firstItemOffset` consistently:

### Change 1: Line 95 (Binary Search)
```typescript
// Before:
(index) => recyclerViewManager.getLayout(index).y

// After:
(index) => recyclerViewManager.getLayout(index).y - recyclerViewManager.firstItemOffset
```

### Change 2: Lines 109-110 (Push Calculation)
```typescript
// Before:
: (recyclerViewManager.tryGetLayout(newNextStickyIndex)?.y ?? 0) +
  recyclerViewManager.firstItemOffset;

// After:
: (recyclerViewManager.tryGetLayout(newNextStickyIndex)?.y ?? 0) -
  recyclerViewManager.firstItemOffset;
```

## 📊 Behavior Comparison

### Before Fix ❌
- Sticky header activates when header is still **below** the viewport top
- Visual duplication: original header + premature sticky overlay
- Inconsistent behavior based on `firstItemOffset` value
- Poor user experience in lists with padding/spacing

### After Fix ✅
- Sticky header activates **exactly** when header top edge touches viewport top
- Smooth, single-header transition
- Consistent behavior regardless of `firstItemOffset`
- Proper sticky header timing in all configurations

## 🧪 Testing

Tested scenarios:
- ✅ Lists with sticky headers and top padding (`firstItemOffset > 0`)
- ✅ Multiple consecutive sticky headers
- ✅ Fast scrolling (both directions)
- ✅ Various header heights (small, medium, large)
- ✅ Lists with `firstItemOffset = 0` (no regression)
- ✅ Lists with header components (ListHeaderComponent)

Test environment:
- React Native calendar/agenda implementation
- iOS and Android platforms
- Various screen sizes

## 📝 Implementation Details

**File modified:** `src/recyclerview/components/StickyHeaders.tsx`

**Lines changed:** 2
- Line 95: Added `- recyclerViewManager.firstItemOffset` to binary search
- Line 109: Changed `+` to `-` for `firstItemOffset` in push calculation

**Breaking changes:** None

**Performance impact:** None (same number of calculations, corrected math only)

## 🎯 Impact

This fix resolves sticky header timing issues for any FlashList with:
- `stickyHeaderIndices` prop defined
- Non-zero `firstItemOffset` value

Common affected use cases:
- 📅 Calendar/agenda views with date section headers
- 📂 Grouped/categorized lists with section headers
- 📋 Lists with decorative top spacing or margins
- 📱 Lists with fixed header components

## 🔗 Related

This issue affects lists where `firstItemOffset` represents:
- Padding/margin before first list item
- Height of ListHeaderComponent
- Any offset between scroll view and child container

The coordinate normalization ensures accurate comparison between scroll position and item positions.

---

## Code Changes Summary

```diff
// src/recyclerview/components/StickyHeaders.tsx

  const currentIndexInArray = findCurrentStickyIndex(
    sortedIndices,
    adjustedScrollOffset,
-   (index) => recyclerViewManager.getLayout(index).y
+   (index) => recyclerViewManager.getLayout(index).y - recyclerViewManager.firstItemOffset
  );

  const newNextStickyY =
    newNextStickyIndex === -1
      ? Number.MAX_SAFE_INTEGER
-     : (recyclerViewManager.tryGetLayout(newNextStickyIndex)?.y ?? 0) +
+     : (recyclerViewManager.tryGetLayout(newNextStickyIndex)?.y ?? 0) -
        recyclerViewManager.firstItemOffset;
```

---

**Ready to merge?** This fix ensures sticky headers work correctly in all FlashList configurations! 🚀

