### PR TITLE
fix: prevent accessing undefined layout in RecyclerView LinearLayoutManager

### DIFF
--- a/src/recyclerview/layout-managers/LinearLayoutManager.ts
+++ b/src/recyclerview/layout-managers/LinearLayoutManager.ts
@@ -63,6 +63,7 @@ export class RVLinearLayoutManagerImpl extends RVLayoutManager {
     for (const info of layoutInfo) {
       const { index, dimensions } = info;
       const layout = this.layouts[index];
+      if (!layout) continue;
       layout.width = this.horizontal ? dimensions.width : this.boundedSize;
       layout.isHeightMeasured = true;
       layout.isWidthMeasured = true;
@@ -80,6 +81,7 @@ export class RVLinearLayoutManagerImpl extends RVLayoutManager {
    */
   estimateLayout(index: number) {
     const layout = this.layouts[index];
+    if (!layout) return;
     layout.width = this.horizontal
       ? this.getEstimatedWidth(index)
       : this.boundedSize;
@@ -114,6 +116,7 @@ export class RVLinearLayoutManagerImpl extends RVLayoutManager {
     for (const info of layoutInfo) {
       const { index } = info;
       const layout = this.layouts[index];
+      if (!layout) continue;
       if (
         layout.height > (layout.minHeight ?? 0) &&
         layout.height > (newTallestItem?.height ?? 0)


### PR DESCRIPTION
## Description

Related to https://github.com/shop/world/pull/330445
Looks like a similar issue to https://github.com/Shopify/flash-list/pull/1922

Fix flash-list race condition crash happening on POS app start with a populated cart, on Tablet.
Added guard to check if layout exists before setting properties.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- On POS, populate cart with items
- Restart App multiple times
- Verify no crash happens

## Screenshots or videos (if needed)

<img width="1027" height="753" alt="Screenshot 2025-12-18 at 2 42 32 PM" src="https://github.com/user-attachments/assets/ce5d49c4-0fdb-4330-92ec-687d9075fa6a" />


<table>
  <tr>
    <td><b>Nightly build crash (0:26)</b></td>
    <td><b>Rn 0.83 crash (0:21)</b></td>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/33eaf77b-8377-498b-8f01-edd4eb9ee6a9" width="300" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/51202823-c159-4b3e-99f5-efa8650be300" width="300" controls></video>
    </td>
  </tr>
</table>
