### PR TITLE
Fix infinite render loop by guaranteeing layout commit.

### DIFF
--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -93,6 +93,10 @@ const RecyclerViewComponent = <T,>(
 
   renderTimeTracker.startTracking();
 
+  const layoutRetryCountRef = useRef(0);
+  const MAX_LAYOUT_RETRIES = 5;
+
+
   // Sticky header config
   const stickyHeaderOffset = stickyHeaderConfig?.offset ?? 0;
   const stickyHeaderUseNativeDriver =
@@ -183,7 +187,7 @@ const RecyclerViewComponent = <T,>(
         },
         isHorizontalRTL && recyclerViewManager.hasLayout()
           ? firstItemOffset -
-              recyclerViewManager.getChildContainerDimensions().width
+          recyclerViewManager.getChildContainerDimensions().width
           : firstItemOffset
       );
     }
@@ -227,16 +231,33 @@ const RecyclerViewComponent = <T,>(
       console.warn(WarningMessages.exceededMaxRendersWithoutCommit);
     }
 
-    if (
-      recyclerViewManager.modifyChildrenLayout(layoutInfo, data?.length ?? 0) &&
-      !hasExceededMaxRendersWithoutCommit
-    ) {
-      // Trigger re-render if layout modifications were made
-      setRenderId((prev) => prev + 1);
-    } else {
+    const layoutChanged = recyclerViewManager.modifyChildrenLayout(
+      layoutInfo,
+      data?.length ?? 0
+    );
+
+    const shouldRetryLayout =
+      layoutChanged && !hasExceededMaxRendersWithoutCommit;
+
+    const commitLayoutAndCorrectOffset = () => {
+      layoutRetryCountRef.current = 0;
       viewHolderCollectionRef.current?.commitLayout();
       applyOffsetCorrection();
+    };
+
+
+    if (shouldRetryLayout) {
+      layoutRetryCountRef.current += 1;
+
+      if (layoutRetryCountRef.current <= MAX_LAYOUT_RETRIES) {
+        // Retry render to stabilize layout
+        setRenderId((prev) => prev + 1);
+        return;
+      }
     }
+    // Commit path: layout is stable OR retries exhausted
+    commitLayoutAndCorrectOffset();
+
 
     if (
       horizontal &&
@@ -585,8 +606,8 @@ const RecyclerViewComponent = <T,>(
               return Math.max(
                 0,
                 windowSize -
-                  childContainerSize -
-                  recyclerViewManager.firstItemOffset
+                childContainerSize -
+                recyclerViewManager.firstItemOffset
               );
             }}
             refHolder={refHolder}


### PR DESCRIPTION
Description

Fixes #2013

Ensures layout convergence when modifyChildrenLayout repeatedly invalidates layout without reaching a commit.

In rare timing-dependent scenarios (e.g. variable item measurements, anchoring, concurrent layout effects), layout could continuously change by small amounts, causing repeated setRenderId calls inside a layout effect and preventing commitLayout from ever executing. This resulted in unnecessary re-renders and the “Exceeded max renders without commit” warning.

This change bounds layout retries and forces a commit after a small number of attempts, guaranteeing forward progress while leaving stable layout behavior unchanged.

Affected package(s):

@shopify/flash-list
```

Reviewers’ hat-rack 🎩

Verify the bounded retry logic in the layout effect

Confirm commitLayout is guaranteed without impacting stable cases

Confirm no changes to scroll-driven render paths

 Prevent unbounded layout re-renders

 Guarantee layout commit

 No behavior change for stable layouts
```

Screenshots or videos

Not applicable (internal layout/rendering fix).