### PR TITLE
Fix sticky header list disappearing when currentStickyIndex -1 on RN 0.83

### DIFF
--- a/src/__tests__/StickyHeaders.test.tsx
+++ b/src/__tests__/StickyHeaders.test.tsx
@@ -446,13 +446,9 @@ describe("StickyHeaders - Compute Function", () => {
       );
 
       // At scroll 100, we're before item 5 (y=250)
-      // Binary search returns -1, but component handles this gracefully
-      // The component should still render but not display any sticky header
-      expect(result).toContainReactComponent(Animated.View);
-
-      // When there's no valid sticky header, the callback might not be invoked
-      // or might be invoked with -1 depending on implementation
-      // Let's just verify the component doesn't crash
+      // Binary search returns -1, so no sticky header should be displayed
+      // The component returns null when there's no valid sticky header
+      expect(result).not.toContainReactComponent(Animated.View);
     });
 
     it("should handle when next sticky header is beyond engaged indices", () => {

--- a/src/recyclerview/components/StickyHeaders.tsx
+++ b/src/recyclerview/components/StickyHeaders.tsx
@@ -228,6 +228,10 @@ export const StickyHeaders = <TItem,>({
     stickyHeaderOffset,
   ]);
 
+  if (currentStickyIndex === -1) {
+    return null;
+  }
+
   return headerContent;
 };
 


### PR DESCRIPTION
### TL;DR

Fixes FlashList becoming invisible (but still interactive) when scrolling up past all sticky headers on React Native 0.83. When `currentStickyIndex` becomes `-1`, the `translateY` interpolation gets `inputRange: [0, 0]`, causing division by zero → `translateY: -Infinity` → view positioned off-screen.

### What changed?

Added early return `null` when `currentStickyIndex === -1` to prevent creating the invalid `[0, 0]` interpolation.

### Root cause (confirmed via logging)

When scrolling up triggers `currentStickyIndex: -1`:
- `pushStartsAt` becomes `0`, `currentStickyHeight` is `0`
- Creates `inputRange: [0, 0]` interpolation
- With `scrollY: -1`: `(-1 - 0) / (0 - 0)` = `-1 / 0` = `-Infinity`
- View gets `translateY: -Infinity` → native layer can't render it
- View invisible but still in hierarchy → receives touches

<table>
  <tr>
    <td><b>Before</b></td>
    <td><b>After</b></td>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/6133be83-2b84-4141-b8c7-a8c9f7fcf3c1" width="300" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/100b13cc-21e7-4445-ace4-5dbbd1832c1b" width="300" controls></video>
    </td>
  </tr>
</table>

### How to test?

1. Use a FlashList with `stickyHeaderIndices` on RN 0.83
2. Scroll up past all sticky headers (pull-to-refresh gesture)
3. Verify the list remains visible