### PR TITLE
docs: remove references to non-existing methods

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -907,12 +907,12 @@ Param `offset` expects the offset to scroll to. In case of `horizontal` is true,
 
 Param `animated` (`false` by default) defines whether the list should do an animation while scrolling.
 
-### `getVisibleIndices()`
+### `computeVisibleIndices()`
 
-Returns an array of indices that are currently visible in the list.
+Returns the start and end indices of the items currently visible in the list.
 
 ```tsx
-getVisibleIndices(): number[];
+computeVisibleIndices(): { startIndex: number; endIndex: number };
 ```
 
 ### `getLayout()`

--- a/documentation/docs/v2-changes.md
+++ b/documentation/docs/v2-changes.md
@@ -80,7 +80,7 @@ sidebar_position: 4
 - FlashList does not ask for any estimates, which makes it much easier to use.
 - Horizontal Lists are much improved, and items can also resize within the lists. We no longer render an extra item to measure list height.
 - In Grid layout, if side-by-side items have different heights, then the shorter item will match the height of the tallest item. This wasn't possible in v1.
-- The ref of FlashList has many more useful methods like `getVisibleIndices` and `getLayout`.
+- The ref of FlashList has many more useful methods like `computeVisibleIndices` and `getLayout`.
 - `contentContainerStyle` prop is fully supported now.
 
 ## New hooks

--- a/src/FlashListRef.ts
+++ b/src/FlashListRef.ts
@@ -266,7 +266,7 @@ export interface FlashListRef<T> {
    * @returns An object with startIndex and endIndex properties
    *
    * @example
-   * const { startIndex, endIndex } = listRef.current?.getVisibleIndices();
+   * const { startIndex, endIndex } = listRef.current?.computeVisibleIndices();
    * console.log(`Visible items: ${startIndex} to ${endIndex}`);
    */
   computeVisibleIndices: () => { startIndex: number; endIndex: number };


### PR DESCRIPTION
## Description

I noticed the docs are referencing a method that does not exist `getVisibleIndices`.

I am guessing the method referred to is `computeVisibleIndices`. Best example is the example for `computeVisibleIndices` itself.