### PR TITLE
Fix sticky header flashing on RN > 0.83

### DIFF
--- a/src/native/config/PlatformHelper.android.ts
+++ b/src/native/config/PlatformHelper.android.ts
@@ -1,7 +1,10 @@
+import { isRN083OrAbove } from "./versionCheck";
+
 const PlatformConfig = {
   defaultDrawDistance: 250,
   supportsOffsetCorrection: true,
   trackAverageRenderTimeForOffsetProjection: true,
+  isRN083OrAbove: isRN083OrAbove(),
 };
 
 export { PlatformConfig };

--- a/src/native/config/PlatformHelper.ios.ts
+++ b/src/native/config/PlatformHelper.ios.ts
@@ -1,7 +1,10 @@
+import { isRN083OrAbove } from "./versionCheck";
+
 const PlatformConfig = {
   defaultDrawDistance: 250,
   supportsOffsetCorrection: true,
   trackAverageRenderTimeForOffsetProjection: false,
+  isRN083OrAbove: isRN083OrAbove(),
 };
 
 export { PlatformConfig };

--- a/src/native/config/PlatformHelper.ts
+++ b/src/native/config/PlatformHelper.ts
@@ -2,6 +2,7 @@ const PlatformConfig = {
   defaultDrawDistance: 250,
   supportsOffsetCorrection: false,
   trackAverageRenderTimeForOffsetProjection: false,
+  isRN083OrAbove: true,
 };
 
 export { PlatformConfig };

--- a/src/native/config/PlatformHelper.web.ts
+++ b/src/native/config/PlatformHelper.web.ts
@@ -2,6 +2,7 @@ const PlatformConfig = {
   defaultDrawDistance: 500,
   supportsOffsetCorrection: false,
   trackAverageRenderTimeForOffsetProjection: false,
+  isRN083OrAbove: true,
 };
 
 export { PlatformConfig };

--- a/src/native/config/versionCheck.ts
+++ b/src/native/config/versionCheck.ts
@@ -1,0 +1,6 @@
+import { Platform } from "react-native";
+
+const rnVersion = Platform.constants?.reactNativeVersion;
+
+export const isRN083OrAbove = () =>
+  rnVersion && (rnVersion.major > 0 || rnVersion.minor >= 83);

--- a/src/recyclerview/components/StickyHeaders.tsx
+++ b/src/recyclerview/components/StickyHeaders.tsx
@@ -15,6 +15,7 @@ import React, {
 import { Animated, NativeScrollEvent } from "react-native";
 
 import { FlashListProps } from "../..";
+import { PlatformConfig } from "../../native/config/PlatformHelper";
 import { RecyclerViewManager } from "../RecyclerViewManager";
 import { ViewHolder } from "../ViewHolder";
 
@@ -228,7 +229,7 @@ export const StickyHeaders = <TItem,>({
     stickyHeaderOffset,
   ]);
 
-  if (currentStickyIndex === -1) {
+  if (PlatformConfig.isRN083OrAbove && currentStickyIndex === -1) {
     return null;
   }
 


### PR DESCRIPTION

Keep the sticky container mounted on older RN versions even when there's no active sticky header. On RN 0.83+, we can safely unmount when not needed.