### PR TITLE
Fix index out of bounds in viewability computation

### DIFF
--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -289,7 +289,8 @@ export class RecyclerViewManager<T> {
   }
 
   recomputeViewableItems() {
-    this.itemViewabilityManager.recomputeViewableItems();
+    this.itemViewabilityManager.clearLastReportedViewableIndices();
+    this.computeItemViewability();
   }
 
   processDataUpdate() {

--- a/src/recyclerview/viewability/ViewabilityManager.ts
+++ b/src/recyclerview/viewability/ViewabilityManager.ts
@@ -89,12 +89,10 @@ export default class ViewabilityManager<T> {
     });
   };
 
-  public recomputeViewableItems = () => {
+  public clearLastReportedViewableIndices = () => {
     this.viewabilityHelpers.forEach((viewabilityHelper) =>
       viewabilityHelper.clearLastReportedViewableIndices()
     );
-
-    this.updateViewableItems();
   };
 
   /**


### PR DESCRIPTION
## Summary

Fixes an index out of bounds error in viewability computation.

## Problem

The previous implementation of `recomputeViewableItems()` would:
1. Clear the last reported viewable indices
2. Immediately call `updateViewableItems()`

This could use stale or invalid indices leading to index out of bounds errors when the data has changed.

## Solution

This fix separates the operations in `RecyclerViewManager.recomputeViewableItems()`:
1. Clear the last reported viewable indices via `clearLastReportedViewableIndices()`
2. Call `computeItemViewability()` which properly computes fresh visible indices before updating viewable items

This ensures the indices are always freshly computed from the current state before being used, preventing index out of bounds errors.

## Changes

- `ViewabilityManager.recomputeViewableItems()` renamed to `clearLastReportedViewableIndices()` and simplified to only clear indices
- `RecyclerViewManager.recomputeViewableItems()` now calls `clearLastReportedViewableIndices()` followed by `computeItemViewability()`