### PR TITLE
fix(sticky-headers): prevent duplicate headers when content is above FlashList

### DIFF
--- a/.claude/skills/agent-device/SKILL.md
+++ b/.claude/skills/agent-device/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: agent-device
+description: Automates interactions for iOS simulators/devices and Android emulators/devices. Use when navigating apps, taking snapshots/screenshots, tapping, typing, scrolling, or extracting UI info on mobile targets.
+---
+
+# Mobile Automation with agent-device
+
+For exploration, use snapshot refs. For deterministic replay, use selectors.
+For structured exploratory QA bug hunts and reporting, use [../dogfood/SKILL.md](../dogfood/SKILL.md).
+
+## Prerequisites
+
+Before running any commands, verify `agent-device` is installed:
+
+```bash
+which agent-device
+```
+
+If the command is not found, prompt the user to install it:
+
+```
+agent-device is not installed. Install it by running:
+
+  npm install -g agent-device
+
+Then re-run your request.
+```
+
+Do not proceed with any `agent-device` commands until the tool is available.
+
+## Start Here (Read This First)
+
+Use this skill as a router, not a full manual.
+
+1. Pick one mode:
+   - Normal interaction flow
+   - Debug/crash flow
+   - Replay maintenance flow
+2. Run one canonical flow below.
+3. Open references only if blocked.
+
+## Decision Map
+
+- No target context yet: `devices` -> pick target -> `open`.
+- Normal UI task: `open` -> `snapshot -i` -> `press/fill` -> `diff snapshot -i` -> `close`
+- Debug/crash: `open <app>` -> `logs clear --restart` -> reproduce -> `network dump` -> `logs path` -> targeted `grep`
+- Replay drift: `replay -u <path>` -> verify updated selectors
+- Remote multi-tenant run: allocate lease -> run commands with tenant isolation flags -> heartbeat/release lease
+
+## Canonical Flows
+
+### 1) Normal Interaction Flow
+
+```bash
+agent-device open Settings --platform ios
+agent-device snapshot -i
+agent-device press @e3
+agent-device diff snapshot -i
+agent-device fill @e5 "test"
+agent-device close
+```
+
+### 2) Debug/Crash Flow
+
+```bash
+agent-device open MyApp --platform ios
+agent-device logs clear --restart
+agent-device network dump 25
+agent-device logs path
+```
+
+Logging is off by default. Enable only for debugging windows.
+`logs clear --restart` requires an active app session (`open <app>` first).
+
+### 3) Replay Maintenance Flow
+
+```bash
+agent-device replay -u ./session.ad
+```
+
+### 4) Remote Tenant Lease Flow (HTTP JSON-RPC)
+
+```bash
+# Allocate lease
+curl -sS http://127.0.0.1:${AGENT_DEVICE_DAEMON_HTTP_PORT}/rpc \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"jsonrpc":"2.0","id":"alloc-1","method":"agent_device.lease.allocate","params":{"runId":"run-123","tenantId":"acme","ttlMs":60000}}'
+
+# Use lease in tenant-isolated command execution
+agent-device --daemon-transport http \
+  --tenant acme \
+  --session-isolation tenant \
+  --run-id run-123 \
+  --lease-id <lease-id> \
+  session list --json
+
+# Heartbeat and release
+curl -sS http://127.0.0.1:${AGENT_DEVICE_DAEMON_HTTP_PORT}/rpc \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"jsonrpc":"2.0","id":"hb-1","method":"agent_device.lease.heartbeat","params":{"leaseId":"<lease-id>","ttlMs":60000}}'
+curl -sS http://127.0.0.1:${AGENT_DEVICE_DAEMON_HTTP_PORT}/rpc \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"jsonrpc":"2.0","id":"rel-1","method":"agent_device.lease.release","params":{"leaseId":"<lease-id>"}}'
+```
+
+## Command Skeleton (Minimal)
+
+### Session and navigation
+
+```bash
+agent-device devices
+agent-device open [app|url] [url]
+agent-device open [app] --relaunch
+agent-device close [app]
+agent-device session list
+```
+
+Use `boot` only as fallback when `open` cannot find/connect to a ready target.
+Use `--target mobile|tv` with `--platform` (required) to pick phone/tablet vs TV targets (AndroidTV/tvOS).
+
+TV quick reference:
+- AndroidTV: `open`/`apps` use TV launcher discovery automatically.
+- TV target selection works on emulators/simulators and connected physical devices (AndroidTV + AppleTV).
+- tvOS: runner-driven interactions and snapshots are supported (`snapshot`, `wait`, `press`, `fill`, `get`, `scroll`, `back`, `home`, `app-switcher`, `record` and related selector flows).
+- tvOS `back`/`home`/`app-switcher` map to Siri Remote actions (`menu`, `home`, double-home) in the runner.
+- tvOS follows iOS simulator-only command semantics for helpers like `pinch`, `settings`, and `push`.
+
+### Snapshot and targeting
+
+```bash
+agent-device snapshot -i
+agent-device diff snapshot -i
+agent-device find "Sign In" click
+agent-device press @e1
+agent-device fill @e2 "text"
+agent-device is visible 'id="anchor"'
+```
+
+`press` is canonical tap command; `click` is an alias.
+
+### Utilities
+
+```bash
+agent-device appstate
+agent-device clipboard read
+agent-device clipboard write "token"
+agent-device perf --json
+agent-device network dump [limit] [summary|headers|body|all]
+agent-device push <bundle|package> <payload.json|inline-json>
+agent-device get text @e1
+agent-device screenshot out.png
+agent-device settings permission grant notifications
+agent-device settings permission reset camera
+agent-device trace start
+agent-device trace stop ./trace.log
+```
+
+### Batch (when sequence is already known)
+
+```bash
+agent-device batch --steps-file /tmp/batch-steps.json --json
+```
+
+### Performance Check
+
+- Use `agent-device perf --json` (or `metrics --json`) after `open`.
+- For detailed metric semantics, caveats, and interpretation guidance, see [references/perf-metrics.md](references/perf-metrics.md).
+
+## Guardrails (High Value Only)
+
+- Re-snapshot after UI mutations (navigation/modal/list changes).
+- Prefer `snapshot -i`; scope/depth only when needed.
+- Use refs for discovery, selectors for replay/assertions.
+- Use `fill` for clear-then-type semantics; use `type` for focused append typing.
+- iOS `appstate` is session-scoped; Android `appstate` is live foreground state.
+- Clipboard helpers: `clipboard read` / `clipboard write <text>` are supported on Android and iOS simulators; iOS physical devices are not supported yet.
+- `network dump` is best-effort and parses HTTP(s) entries from the session app log file.
+- Biometric settings: iOS simulator supports `settings faceid|touchid <match|nonmatch|enroll|unenroll>`; Android supports `settings fingerprint <match|nonmatch>` where runtime tooling is available.
+- For AndroidTV/tvOS selection, always pair `--target` with `--platform` (`ios`, `android`, or `apple` alias); target-only selection is invalid.
+- `push` simulates notification delivery:
+  - iOS simulator uses APNs-style payload JSON.
+  - Android uses broadcast action + typed extras (string/boolean/number).
+- Permission settings are app-scoped and require an active session app:
+  `settings permission <grant|deny|reset> <camera|microphone|photos|contacts|notifications> [full|limited]`
+- `full|limited` mode applies only to iOS `photos`; other targets reject mode.
+- On Android, non-ASCII `fill/type` may require an ADB keyboard IME on some system images; only install IME APKs from trusted sources and verify checksum/signature.
+- If using `--save-script`, prefer explicit path syntax (`--save-script=flow.ad` or `./flow.ad`).
+- For tenant-isolated remote runs, always pass `--tenant`, `--session-isolation tenant`, `--run-id`, and `--lease-id` together.
+- Use short lease TTLs and heartbeat only while work is active; release leases immediately after run completion/failure.
+
+## Security and Trust Notes
+
+- Prefer a preinstalled `agent-device` binary over on-demand package execution.
+- If install is required, pin an exact version (for example: `npx --yes agent-device@<exact-version> --help`).
+- Signing/provisioning environment variables are optional, sensitive, and only for iOS physical-device setup.
+- Logs/artifacts are written under `~/.agent-device`; replay scripts write to explicit paths you provide.
+- For remote daemon mode, prefer `AGENT_DEVICE_DAEMON_SERVER_MODE=http|dual` with `AGENT_DEVICE_HTTP_AUTH_HOOK` and tenant-scoped lease admission.
+- Keep logging off unless debugging and use least-privilege/isolated environments for autonomous runs.
+
+## Common Mistakes
+
+- Mixing debug flow into normal runs (keep logs off unless debugging).
+- Continuing to use stale refs after screen transitions.
+- Using URL opens with Android `--activity` (unsupported combination).
+- Treating `boot` as default first step instead of fallback.
+
+## References
+
+- [references/snapshot-refs.md](references/snapshot-refs.md)
+- [references/logs-and-debug.md](references/logs-and-debug.md)
+- [references/session-management.md](references/session-management.md)
+- [references/permissions.md](references/permissions.md)
+- [references/video-recording.md](references/video-recording.md)
+- [references/coordinate-system.md](references/coordinate-system.md)
+- [references/batching.md](references/batching.md)
+- [references/perf-metrics.md](references/perf-metrics.md)
+- [references/remote-tenancy.md](references/remote-tenancy.md)

--- a/.claude/skills/agent-device/references/batching.md
+++ b/.claude/skills/agent-device/references/batching.md
@@ -1,0 +1,79 @@
+# Batching
+
+## When to use batch
+
+- The agent already knows a short sequence of commands.
+- Steps belong to one logical screen flow.
+- You want one result object with per-step timing and failure context.
+
+## When not to use batch
+
+- Flows are unrelated and should be retried independently.
+- The workflow is highly dynamic and requires replanning after each step.
+- You need human approvals between steps.
+
+## CLI patterns
+
+From file:
+
+```bash
+agent-device batch --session sim --platform ios --steps-file /tmp/batch-steps.json --json
+```
+
+Inline (small payloads only):
+
+```bash
+agent-device batch --steps '[{"command":"open","positionals":["settings"]}]'
+```
+
+## Step payload contract
+
+```json
+[
+  { "command": "open", "positionals": ["settings"], "flags": {} },
+  { "command": "wait", "positionals": ["label=\"Privacy & Security\"", "3000"], "flags": {} },
+  { "command": "click", "positionals": ["label=\"Privacy & Security\""], "flags": {} },
+  { "command": "get", "positionals": ["text", "label=\"Tracking\""], "flags": {} }
+]
+```
+
+Rules:
+
+- `positionals` optional, defaults to `[]`.
+- `flags` optional, defaults to `{}`.
+- nested `batch` and `replay` are rejected.
+- stop-on-first-error is the supported mode (`--on-error stop`).
+
+## Response handling
+
+Success includes:
+
+- `total`, `executed`, `totalDurationMs`
+- `results[]` entries with `step`, `command`, `durationMs`, and optional `data`
+
+Failure includes:
+
+- `details.step`
+- `details.command`
+- `details.executed`
+- `details.partialResults`
+
+Use these fields to replan from the first failing step.
+
+## Common error categories and agent actions
+
+- `INVALID_ARGS`: payload/step shape issue; fix payload and retry.
+- `SESSION_NOT_FOUND`: open or select the correct session, then retry.
+- `UNSUPPORTED_OPERATION`: switch command/target to supported operation.
+- `AMBIGUOUS_MATCH`: refine selector/locator, then retry failed step.
+- `COMMAND_FAILED`: add sync guard (`wait`, `is exists`) and retry from failed step.
+
+## Reliability guardrails
+
+- Add sync guards after mutating steps.
+- Assume snapshot/ref drift after navigation.
+- Keep batch size moderate (about 5-20 steps).
+- Split long workflows into phases:
+  1. navigate
+  2. verify/extract
+  3. cleanup

--- a/.claude/skills/agent-device/references/coordinate-system.md
+++ b/.claude/skills/agent-device/references/coordinate-system.md
@@ -1,0 +1,8 @@
+# Coordinate System
+
+All coordinate-based actions use device screen coordinates:
+
+- Origin: top-left of the device screen
+- Units: device points for iOS, pixels for Android
+
+Use screenshots to reason about coordinates.

--- a/.claude/skills/agent-device/references/logs-and-debug.md
+++ b/.claude/skills/agent-device/references/logs-and-debug.md
@@ -1,0 +1,113 @@
+# Logs (Token-Efficient Debugging)
+
+Logging is off by default in normal flows. Enable it on demand for debugging windows. App output is written to a session-scoped file so agents can grep it instead of loading full logs into context.
+`network dump` parses recent HTTP(s) entries from this same session app log file.
+
+## Data Handling
+
+- Default app logs are stored under `~/.agent-device/sessions/<session>/app.log`.
+- Replay scripts saved with `--save-script` are written to the explicit path you provide.
+- Log files may contain sensitive runtime data; review before sharing and clean up when finished.
+- Use `AGENT_DEVICE_APP_LOG_REDACT_PATTERNS` to redact sensitive patterns at write time when needed.
+
+## Retention and Cleanup
+
+- Keep logging scoped to active debug windows (`logs clear --restart` before repro, `logs stop` after repro).
+- Prefer bounded inspection (`grep -n`, `tail -50`) instead of reading full logs into context.
+- Clear session logs when finished:
+  `agent-device logs clear`
+- Close session to stop background logging state:
+  `agent-device close`
+
+## Quick Flow
+
+```bash
+agent-device open MyApp --platform ios      # or --platform android
+agent-device logs clear --restart    # Preferred: stop stream, clear logs, and start streaming again
+agent-device network dump 25         # Parse latest HTTP(s) requests (method/url/status) from app.log
+agent-device logs path               # Print path, e.g. ~/.agent-device/sessions/default/app.log
+agent-device logs doctor             # Check tool/runtime readiness for current session/device
+agent-device logs mark "before tap"  # Insert a timeline marker into app.log
+# ... run flows; on failure, grep the path (see below)
+agent-device logs stop               # Stop streaming (optional; close also stops)
+```
+
+Precondition: `logs clear --restart` requires an active app session (`open <app>` first).
+
+## Command Notes
+
+- `logs path`: returns log file path and metadata (`active`, `state`, `backend`, size, timestamps).
+- `logs start`: starts streaming; requires an active app session (`open` first). Supported on iOS simulator, iOS device, and Android.
+- `logs stop`: stops streaming. Session `close` also stops logging.
+- `logs clear`: truncates `app.log` and removes rotated `app.log.N` files. Requires logging to be stopped first.
+- `logs clear --restart`: convenience reset for repro loops (stop stream, clear files, restart stream).
+- `logs doctor`: reports backend/tool checks and readiness notes for troubleshooting.
+- `logs mark`: writes a timestamped marker line to the session log.
+- `network dump [limit] [summary|headers|body|all]`: parses recent HTTP(s) lines from the session app log and returns request summaries.
+- `network log ...`: alias for `network dump`.
+
+## Behavior and Limits
+
+- `logs start` appends to `app.log` and rotates to `app.log.1` when `app.log` exceeds 5 MB.
+- `network dump` scans the last 4000 app-log lines, returns up to 200 entries, and truncates payload/header fields at 2048 characters.
+- Android log streaming automatically rebinds to the app PID after process restarts.
+- iOS log capture relies on Unified Logging signals (for example `os_log`); plain stdout/stderr output may be limited depending on app/runtime.
+- Retention knobs:
+  - `AGENT_DEVICE_APP_LOG_MAX_BYTES`
+  - `AGENT_DEVICE_APP_LOG_MAX_FILES`
+- Optional write-time redaction patterns:
+  - `AGENT_DEVICE_APP_LOG_REDACT_PATTERNS` (comma-separated regex)
+
+## Grep Patterns
+
+After getting the path from `logs path`, run `grep` (or `grep -E`) so only matching lines enter context.
+
+```bash
+# Get path first, then grep it; -n adds line numbers
+grep -n "Error\|Exception\|Fatal" <path>
+grep -n -E "Error|Exception|Fatal|crash" <path>
+
+# Bounded context: last N lines only
+tail -50 <path>
+```
+
+- Use `-n` for line numbers.
+- Use `-E` for extended regex so `|` in the pattern does not need escaping.
+- Prefer targeted patterns (e.g. `Error`, `Exception`, or app-specific tags) over reading the full file.
+
+## Crash Triage Fast Path
+
+Always start from the session app log, then branch by platform.
+
+```bash
+agent-device logs path
+grep -n -E "SIGABRT|SIGSEGV|EXC_|fatal|exception|terminated|killed|jetsam|memorystatus|FATAL EXCEPTION|Abort message" <path>
+nl -ba <path> | sed -n '<start>,<end>p'
+```
+
+### iOS
+
+```bash
+# If log shows ReportCrash / SIGABRT / EXC_*, inspect simulator DiagnosticReports:
+ls -lt ~/Library/Logs/DiagnosticReports | grep -E "<AppName>|<BundleId>" | head
+```
+
+- `SIGABRT`: app/runtime abort; inspect `.ips` triggered thread and top frames.
+- `SIGKILL` + jetsam/memorystatus markers: memory-pressure kill.
+- `EXC_BAD_ACCESS`/`SIGSEGV`: native memory access issue.
+
+### Android
+
+```bash
+# Capture fatal crash lines around app process death:
+adb -s <serial> logcat -d | grep -n -E "FATAL EXCEPTION|Process: <package>|Abort message|signal [0-9]+ \\(SIG"
+```
+
+- `FATAL EXCEPTION` with Java stack: uncaught Java/Kotlin exception.
+- `signal 6 (SIGABRT)` or `signal 11 (SIGSEGV)` with tombstone refs: native crash path (NDK/JNI/runtime).
+- `Low memory killer` / `Killing <pid>` entries: OS memory-pressure/process reclaim.
+
+## Stop Conditions
+
+- If no crash signature appears in app log, switch to platform-native crash sources (`.ips` on iOS, logcat/tombstone flow on Android).
+- If signatures are present and root cause class is identified (abort, native fault, memory pressure), stop collecting broad logs and focus on reproducing the specific path.

--- a/.claude/skills/agent-device/references/perf-metrics.md
+++ b/.claude/skills/agent-device/references/perf-metrics.md
@@ -1,0 +1,53 @@
+# Performance Metrics (`perf` / `metrics`)
+
+Use this reference when you need to measure launch performance in agent workflows.
+
+## Quick flow
+
+```bash
+agent-device open Settings --platform ios
+agent-device perf --json
+```
+
+Alias:
+
+```bash
+agent-device metrics --json
+```
+
+## What is measured today
+
+- Session-scoped `startup` timing only.
+- Sampling method: `open-command-roundtrip`.
+- Unit: milliseconds (`ms`).
+- Source: elapsed wall-clock time around each session `open` command dispatch for the active app target.
+
+## Output fields to use
+
+- `metrics.startup.lastDurationMs`: most recent startup sample.
+- `metrics.startup.lastMeasuredAt`: ISO timestamp of most recent sample.
+- `metrics.startup.sampleCount`: number of retained samples.
+- `metrics.startup.samples[]`: recent startup history for the current session.
+- `sampling.startup.method`: current sampling method identifier.
+
+## Platform support (current)
+
+- iOS simulator: supported for startup sampling.
+- iOS physical device: supported for startup sampling.
+- Android emulator/device: supported for startup sampling.
+- `fps`, `memory`, and `cpu`: currently placeholders (`available: false`).
+
+## Interpretation guidance
+
+- Treat startup values as command round-trip timing, not true app first-frame or first-interactive telemetry.
+- Compare like-for-like runs:
+  - same device target
+  - same app build
+  - same workflow/session steps
+- Use multiple runs and compare trend/median, not one-off samples.
+
+## Common pitfalls
+
+- Running `perf` before any `open` in the session yields no startup sample yet.
+- Comparing values across different devices/runtimes introduces large noise.
+- Interpreting current `startup` as CPU/FPS/memory would be incorrect.

--- a/.claude/skills/agent-device/references/permissions.md
+++ b/.claude/skills/agent-device/references/permissions.md
@@ -1,0 +1,39 @@
+# Permissions and Setup
+
+## iOS snapshots
+
+iOS snapshots use XCTest and do not require macOS Accessibility permissions.
+
+## iOS physical device runner
+
+For iOS physical devices, XCTest runner setup requires valid signing/provisioning.
+Use Automatic Signing in Xcode, or provide optional overrides:
+
+- `AGENT_DEVICE_IOS_TEAM_ID`
+- `AGENT_DEVICE_IOS_SIGNING_IDENTITY`
+- `AGENT_DEVICE_IOS_PROVISIONING_PROFILE`
+
+Security guidance for these overrides:
+
+- These variables are optional and only needed for physical-device XCTest setup.
+- Treat values as sensitive host configuration; do not share in chat logs or commit to source control.
+- Do not provide private keys or unrelated secrets; use the minimum values required for signing.
+- Prefer Xcode Automatic Signing when possible to reduce manual secret/config handling.
+- For autonomous/CI runs, keep these unset by default and require explicit opt-in for physical-device workflows.
+
+If setup/build takes long, increase:
+
+- `AGENT_DEVICE_DAEMON_TIMEOUT_MS` (default `45000`, for example `120000`)
+
+If daemon startup fails with stale metadata hints, clean stale files and retry:
+
+- `~/.agent-device/daemon.json`
+- `~/.agent-device/daemon.lock`
+
+## iOS: "Allow Paste" dialog
+
+iOS 16+ shows an "Allow Paste" prompt when an app reads the system pasteboard. Under XCUITest (which `agent-device` uses), this prompt is suppressed by the testing runtime. Use `xcrun simctl pbcopy booted` to set clipboard content directly on the simulator instead.
+
+## Simulator troubleshooting
+
+- If snapshots return 0 nodes, restart Simulator and re-open the app.

--- a/.claude/skills/agent-device/references/remote-tenancy.md
+++ b/.claude/skills/agent-device/references/remote-tenancy.md
@@ -1,0 +1,77 @@
+# Remote Tenancy and Lease Admission
+
+Use this reference for remote daemon HTTP flows that require explicit
+tenant/run admission control.
+
+## Transport prerequisites
+
+- Start daemon in HTTP mode (`AGENT_DEVICE_DAEMON_SERVER_MODE=http|dual`).
+- Use a token from daemon metadata or `Authorization: Bearer <token>`.
+- Prefer an auth hook (`AGENT_DEVICE_HTTP_AUTH_HOOK`) for caller validation and
+  tenant injection.
+
+## Lease lifecycle (JSON-RPC)
+
+Use `POST /rpc` with JSON-RPC 2.0 methods:
+
+- `agent_device.lease.allocate`
+- `agent_device.lease.heartbeat`
+- `agent_device.lease.release`
+
+Example allocate:
+
+```bash
+curl -sS http://127.0.0.1:${AGENT_DEVICE_DAEMON_HTTP_PORT}/rpc \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"jsonrpc":"2.0","id":"alloc-1","method":"agent_device.lease.allocate","params":{"tenantId":"acme","runId":"run-123","ttlMs":60000}}'
+```
+
+Example heartbeat:
+
+```bash
+curl -sS http://127.0.0.1:${AGENT_DEVICE_DAEMON_HTTP_PORT}/rpc \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"jsonrpc":"2.0","id":"hb-1","method":"agent_device.lease.heartbeat","params":{"leaseId":"<lease-id>","ttlMs":60000}}'
+```
+
+Example release:
+
+```bash
+curl -sS http://127.0.0.1:${AGENT_DEVICE_DAEMON_HTTP_PORT}/rpc \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"jsonrpc":"2.0","id":"rel-1","method":"agent_device.lease.release","params":{"leaseId":"<lease-id>"}}'
+```
+
+## Command admission contract
+
+For tenant-isolated command execution, pass all four flags:
+
+```bash
+agent-device --daemon-transport http \
+  --tenant acme \
+  --session-isolation tenant \
+  --run-id run-123 \
+  --lease-id <lease-id> \
+  session list --json
+```
+
+Admission checks require tenant/run/lease scope alignment.
+
+## Failure semantics
+
+- Missing tenant/run/lease fields in tenant isolation mode: `INVALID_ARGS`
+- Lease not active or wrong scope: `UNAUTHORIZED`
+- Method mismatch: JSON-RPC `-32601` (HTTP 404)
+
+## Operational guidance
+
+- Keep TTL short and heartbeat only while a run is active.
+- Release lease immediately on run completion/error paths.
+- For bounded hosts, configure:
+  - `AGENT_DEVICE_MAX_SIMULATOR_LEASES`
+  - `AGENT_DEVICE_LEASE_TTL_MS`
+  - `AGENT_DEVICE_LEASE_MIN_TTL_MS`
+  - `AGENT_DEVICE_LEASE_MAX_TTL_MS`

--- a/.claude/skills/agent-device/references/session-management.md
+++ b/.claude/skills/agent-device/references/session-management.md
@@ -1,0 +1,45 @@
+# Session Management
+
+## Named sessions
+
+```bash
+agent-device --session auth open Settings --platform ios
+agent-device --session auth snapshot -i
+```
+
+Sessions isolate device context. A device can only be held by one session at a time.
+
+## Best practices
+
+- Name sessions semantically.
+- Close sessions when done.
+- Use separate sessions for parallel work.
+- For remote tenant-scoped automation, run commands with:
+  `--tenant <id> --session-isolation tenant --run-id <id> --lease-id <id>`
+- In iOS sessions, use `open <app>`. `open <url>` opens deep links; on devices `http(s)://` opens Safari when no app is active, and custom schemes require an active app in the session.
+- In iOS sessions, `open <app> <url>` opens a deep link.
+- On iOS, `appstate` is session-scoped and requires a matching active session on the target device.
+- For dev loops where runtime state can persist (for example React Native Fast Refresh), use `open <app> --relaunch` to restart the app process in the same session.
+- Use `--save-script [path]` to record replay scripts on `close`; path is a file path and parent directories are created automatically.
+- For ambiguous bare `--save-script` values, prefer `--save-script=workflow.ad` or `./workflow.ad`.
+- For deterministic replay scripts, prefer selector-based actions and assertions.
+- Use `replay -u` to update selector drift during maintenance.
+
+## Listing sessions
+
+```bash
+agent-device session list
+```
+
+## Replay within sessions
+
+```bash
+agent-device replay ./session.ad --session auth
+agent-device replay -u ./session.ad --session auth
+```
+
+## Tenant isolation note
+
+When session isolation is set to tenant mode, session namespace is scoped as
+`<tenant>:<session>`. For remote runs, allocate and maintain an active lease
+for the same tenant/run scope before executing tenant-isolated commands.

--- a/.claude/skills/agent-device/references/snapshot-refs.md
+++ b/.claude/skills/agent-device/references/snapshot-refs.md
@@ -1,0 +1,82 @@
+# Snapshot Refs and Selectors (Mobile)
+
+## Purpose
+
+Refs are useful for discovery/debugging. For deterministic scripts, use selectors.
+For tap interactions, `press` is canonical; `click` is an equivalent alias.
+
+## Snapshot
+
+```bash
+agent-device snapshot -i
+```
+
+Output:
+
+```
+Page: com.apple.Preferences
+App: com.apple.Preferences
+
+@e1 [ioscontentgroup]
+  @e2 [button] "Camera"
+  @e3 [button] "Privacy & Security"
+```
+
+## Using refs (discovery/debug)
+
+```bash
+agent-device press @e2
+agent-device fill @e5 "test"
+```
+
+## Using selectors (deterministic)
+
+```bash
+agent-device press 'id="camera_row" || label="Camera" role=button'
+agent-device fill 'id="search_input" editable=true' "test"
+agent-device is visible 'id="camera_settings_anchor"'
+```
+
+## Ref lifecycle
+
+Refs can become invalid when UI changes (navigation, modal, dynamic list updates).
+Re-snapshot after transitions if you keep using refs.
+
+## Scope snapshots
+
+Use `-s` to scope to labels/identifiers. This reduces size and speeds up results:
+
+```bash
+agent-device snapshot -i -s "Camera"
+agent-device snapshot -i -s @e3
+```
+
+## Diff snapshots (structural)
+
+Use `diff snapshot` when you need compact state-change visibility between nearby UI states:
+
+```bash
+agent-device snapshot -i           # First snapshot initializes baseline
+agent-device press @e5
+agent-device diff snapshot -i           # Shows +/− structural lines vs prior snapshot
+```
+
+Efficient pattern:
+- Initialize once at a stable point.
+- Mutate UI (`press`, `fill`, `swipe`).
+- Run `diff snapshot` after interactions to confirm expected change shape with bounded output.
+- Re-run full/scoped `snapshot` only when you need fresh refs for next step selection.
+
+## Troubleshooting
+
+- Ref not found: re-snapshot.
+- If XCTest returns 0 nodes, foreground app state may have changed. Re-open the app or retry after state is stable.
+
+## Stop Conditions
+
+- If refs are unstable after UI transitions, switch to selector-based targeting and stop investing in ref-only flows.
+
+## Replay note
+
+- Prefer selector-based actions in recorded `.ad` replays.
+- Use `agent-device replay -u <path>` to update selector drift and rewrite replay scripts in place.

--- a/.claude/skills/agent-device/references/video-recording.md
+++ b/.claude/skills/agent-device/references/video-recording.md
@@ -1,0 +1,41 @@
+# Video Recording
+
+Capture device automation sessions as video for debugging, documentation, or verification
+
+## iOS Simulator
+
+Use `agent-device record` commands (wrapper around simctl):
+
+```bash
+# Start recording
+agent-device record start ./recordings/ios.mov
+
+# Perform actions
+agent-device open App
+agent-device snapshot -i
+agent-device click @e3
+agent-device close
+
+# Stop recording
+agent-device record stop
+```
+
+`record` is iOS simulator-only.
+
+## Android Emulator/Device
+
+Use `agent-device record` commands (wrapper around adb):
+
+```bash
+# Start recording
+agent-device record start ./recordings/android.mp4
+
+# Perform actions
+agent-device open App
+agent-device snapshot -i
+agent-device click @e3
+agent-device close
+
+# Stop recording
+agent-device record stop
+```

--- a/.claude/skills/fix-github-issue/SKILL.md
+++ b/.claude/skills/fix-github-issue/SKILL.md
@@ -1,0 +1,441 @@
+---
+name: fix-github-issue
+description: Full workflow for fixing a FlashList GitHub issue: understand the problem, create a repro sample in the fixture app, diagnose root cause, fix, test on iOS and Android simulators, review, and raise a PR.
+---
+
+# Fix a FlashList GitHub Issue
+
+## Prerequisites
+
+Check all required tools are available before starting:
+
+```bash
+which agent-device && which gh
+```
+
+If `agent-device` is missing:
+```
+agent-device is not installed. Run: npm install -g agent-device
+```
+
+If `gh` is missing:
+```
+GitHub CLI is not installed. Run: brew install gh
+Then authenticate: gh auth login
+```
+
+---
+
+## Running Metro on a Free Port
+
+Default Metro port is 8081. If it's already in use, find a free port and start Metro explicitly.
+
+### Find what's using port 8081
+
+```bash
+lsof -ti :8081
+```
+
+If it returns a PID, either kill it or pick a different port:
+
+```bash
+# Kill whatever is on 8081
+kill -9 $(lsof -ti :8081)
+
+# Or find a free port
+lsof -ti :8082 || echo "8082 is free"
+lsof -ti :8083 || echo "8083 is free"
+```
+
+### Start Metro on a custom port
+
+From `fixture/react-native/`:
+
+```bash
+yarn react-native start --port 8082
+```
+
+Or from the repo root:
+
+```bash
+cd fixture/react-native && yarn start --port 8082
+```
+
+### Tell the simulator to use the custom port
+
+**iOS** — pass the port when building/running:
+
+```bash
+cd fixture/react-native && yarn react-native run-ios --port 8082
+```
+
+**Android** — reverse the port via ADB so the emulator can reach Metro on your machine:
+
+```bash
+adb reverse tcp:8082 tcp:8082
+cd fixture/react-native && yarn react-native run-android --port 8082
+```
+
+### In-app Dev Menu (already running app)
+
+If the app is already installed and running, reload it against the new port without rebuilding:
+
+- **iOS simulator**: `Cmd+D` → "Configure Bundler" → set host `localhost` and port `8082`
+- **Android emulator**: shake or `Cmd+M` → "Configure Bundler" → set host `10.0.2.2` and port `8082`
+
+### Verify Metro is reachable
+
+```bash
+curl -s http://localhost:8082/status
+# Should return: {"status":"packager-status:running"}
+```
+
+---
+
+## Workflow Overview
+
+1. Understand the issue
+2. Create a reproduction sample
+3. Reproduce on iOS and Android
+4. Diagnose root cause
+5. Implement the fix
+6. Verify fix on iOS and Android
+7. Review code changes
+8. Raise a PR
+
+---
+
+## Step 1 — Understand the Issue
+
+Fetch the issue from GitHub:
+
+```bash
+gh issue view <issue-number> --repo Shopify/flash-list
+```
+
+Read the issue thoroughly. Extract:
+- **Symptom**: What the user observes (visual bug, crash, wrong behavior, performance)
+- **Props/config**: Which FlashList props are involved
+- **Platform**: iOS only, Android only, or both
+- **Reproduction steps**: How to trigger the bug
+- **Expected vs actual behavior**
+
+Also fetch any linked PRs or referenced issues for context:
+```bash
+gh issue view <issue-number> --repo Shopify/flash-list --comments
+```
+
+---
+
+## Step 2 — Create a Reproduction Sample
+
+Add a dedicated screen to the fixture app that isolates and reproduces the issue.
+
+### 2a. Create the sample component
+
+Create `fixture/react-native/src/IssueRepro<number>.tsx`:
+
+```tsx
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import FlashList from "../../../../src";
+
+// Minimal reproduction for issue #<number>
+// <brief description of the bug>
+export default function IssueRepro<number>() {
+  // Use the minimum props needed to trigger the bug
+  return (
+    <FlashList
+      data={...}
+      renderItem={...}
+      estimatedItemSize={...}
+    />
+  );
+}
+
+const styles = StyleSheet.create({ ... });
+```
+
+Keep it minimal — only include props that are necessary to trigger the bug.
+
+### 2b. Register the screen
+
+In `fixture/react-native/src/constants.ts`, add to `RootStackParamList`:
+```ts
+IssueRepro<number>: undefined;
+```
+
+In `fixture/react-native/src/NavigationTree.tsx`, add:
+```tsx
+<Stack.Screen name="IssueRepro<number>" component={IssueRepro<number>} />
+```
+
+In `fixture/react-native/src/ExamplesScreen.tsx`, add an entry to the examples list:
+```tsx
+{ title: "Issue #<number>: <short description>", destination: "IssueRepro<number>" }
+```
+
+### 2c. Build
+
+Start or rebuild the TypeScript watcher from the repo root:
+```bash
+yarn build
+```
+
+---
+
+## Step 3 — Reproduce on iOS and Android
+
+Use `agent-device` to navigate to the repro screen and confirm the bug is visible.
+
+### iOS
+
+```bash
+yarn fixture:rn:ios
+```
+
+Then with agent-device:
+```bash
+agent-device open "FlashList" --platform ios
+agent-device snapshot -i
+agent-device find "Issue #<number>" click
+agent-device snapshot -i
+```
+
+Capture the buggy state:
+```bash
+agent-device screenshot repro-ios-before.png
+```
+
+### Android
+
+```bash
+yarn fixture:rn:android
+```
+
+Then:
+```bash
+agent-device open "FlashList" --platform android
+agent-device snapshot -i
+agent-device find "Issue #<number>" click
+agent-device snapshot -i
+agent-device screenshot repro-android-before.png
+```
+
+### Confirm Reproduction
+
+- Describe exactly what you observe on each platform
+- Note if the bug is platform-specific
+- If the bug is not visible in the sample, revisit Step 2 and adjust props/data
+
+---
+
+## Step 4 — Diagnose Root Cause
+
+### Source Code Map
+
+| Area | Location |
+|------|----------|
+| Core component | `src/recyclerview/RecyclerView.tsx` |
+| Layout logic | `src/recyclerview/layout-managers/` |
+| Item recycling | `src/recyclerview/ViewHolder.tsx`, `ViewHolderCollection.tsx` |
+| Scroll behavior | `src/recyclerview/useSecondaryProps.ts` |
+| Visibility/viewability | `src/recyclerview/viewability/` |
+| Sticky headers | `src/recyclerview/StickyHeaders.tsx` |
+| Scroll anchoring | `src/recyclerview/ScrollAnchor.tsx` |
+| Average window | `src/utils/AverageWindow.ts` |
+| Props interface | `src/FlashListProps.ts` |
+
+### Diagnosis Steps
+
+1. Search for the relevant prop or API surface:
+   ```bash
+   grep -r "propName" src/ --include="*.ts" --include="*.tsx" -l
+   ```
+
+2. Trace the code path from prop → render → layout → scroll
+
+3. Add debug logging if needed (remove before the fix lands):
+   ```ts
+   console.log("[debug]", relevantValue);
+   ```
+
+4. Check existing unit tests for the affected area:
+   ```bash
+   yarn test --testPathPattern="RelatedTest"
+   ```
+
+5. Write a hypothesis: "The bug occurs because ____"
+
+---
+
+## Step 5 — Implement the Fix
+
+### Guidelines
+
+- Fix the root cause, not the symptom
+- Keep the change minimal and focused
+- Do not refactor unrelated code
+- Match the existing code style
+
+### Commit message format
+
+```
+fix(<scope>): <concise description of what is fixed>
+```
+
+Examples:
+```
+fix(hooks): eliminate scroll jitter when prepending items at bottom
+fix: filter stale indices from layoutInfo after truncation
+fix(layout): correct estimated size calculation for horizontal lists
+```
+
+### Add or update unit tests
+
+If there is an existing test file for the changed module, add a test case:
+```bash
+# Test files live in:
+src/__tests__/
+```
+
+Run tests after the fix:
+```bash
+yarn test
+yarn type-check
+yarn lint
+```
+
+All three must pass before moving to testing on device.
+
+---
+
+## Step 6 — Verify Fix on iOS and Android
+
+Relaunch both simulators and navigate to the repro screen to confirm the fix.
+
+### iOS
+
+```bash
+agent-device open "FlashList" --platform ios
+agent-device snapshot -i
+agent-device find "Issue #<number>" click
+agent-device snapshot -i
+agent-device screenshot fix-ios-after.png
+```
+
+Compare before/after screenshots visually. Confirm:
+- Bug is no longer present
+- No visual regressions on the repro screen
+- No new warnings in Metro output
+
+### Android
+
+```bash
+agent-device open "FlashList" --platform android
+agent-device snapshot -i
+agent-device find "Issue #<number>" click
+agent-device snapshot -i
+agent-device screenshot fix-android-after.png
+```
+
+### Smoke Test Other Screens
+
+Navigate a few related screens to check for regressions:
+
+```bash
+agent-device find "List" click
+agent-device snapshot -i
+agent-device back
+agent-device find "Grid" click
+agent-device snapshot -i
+agent-device back
+```
+
+If a regression is found, return to Step 5.
+
+---
+
+## Step 7 — Review Code Changes
+
+Show the full diff:
+
+```bash
+git diff
+```
+
+Review checklist:
+- [ ] Fix addresses the root cause described in Step 4
+- [ ] No unrelated changes included
+- [ ] No debug `console.log` statements left in
+- [ ] New test case covers the fix
+- [ ] `yarn test` passes
+- [ ] `yarn type-check` passes
+- [ ] `yarn lint` passes
+- [ ] The repro screen from Step 2 is included in the commit (as a visual reference for reviewers)
+
+If any item fails, fix it before proceeding.
+
+---
+
+## Step 8 — Raise a PR
+
+### Stage and commit
+
+```bash
+git checkout -b fix/issue-<number>-<short-slug>
+git add <specific files>
+git commit -m "fix(<scope>): <description>
+
+Fixes #<number>"
+git push -u origin fix/issue-<number>-<short-slug>
+```
+
+### Create the PR
+
+```bash
+gh pr create \
+  --repo Shopify/flash-list \
+  --title "fix(<scope>): <description>" \
+  --body "$(cat <<'EOF'
+## Description
+
+<Explain what the bug was and how the fix works>
+
+Fixes #<number>
+
+## Reviewers' hat-rack :tophat:
+
+<What to look at — layout logic, hook behavior, edge cases>
+
+## Screenshots or videos
+
+**Before:**
+![iOS before](repro-ios-before.png)
+![Android before](repro-android-before.png)
+
+**After:**
+![iOS after](fix-ios-after.png)
+![Android after](fix-android-after.png)
+
+## Test plan
+- [ ] Repro screen confirms bug is fixed on iOS
+- [ ] Repro screen confirms bug is fixed on Android
+- [ ] No regressions observed on List, Grid, Chat, Carousel screens
+- [ ] Unit tests pass (`yarn test`)
+- [ ] Type check passes (`yarn type-check`)
+EOF
+)"
+```
+
+Return the PR URL to the user.
+
+---
+
+## Common Pitfalls
+
+- **Estimating item size incorrectly in repro** — use a `console.log` in `renderItem` to log actual heights
+- **Repro only triggers after scroll** — add `onEndReached` or prepend items to force the scroll path
+- **Android and iOS behave differently** — always test both; Android uses a native RecyclerView bridge
+- **Stale layout cache** — if sizes look wrong after a fix, call `ref.current?.clearLayoutCacheOnUpdate()`
+- **Prop not forwarded** — check `FlashListProps.ts` and `RecyclerView.tsx` to confirm the prop reaches the layout manager

--- a/fixture/react-native/src/ExamplesScreen.tsx
+++ b/fixture/react-native/src/ExamplesScreen.tsx
@@ -28,6 +28,10 @@ export const ExamplesScreen = () => {
 
   const data: ExampleItem[] = [
     { title: "Sticky Header Example", destination: "StickyHeaderExample" },
+    {
+      title: "Issue #2017: Duplicate Sticky Headers",
+      destination: "IssueRepro2017",
+    },
     { title: "Horizontal List", destination: "HorizontalList" },
     { title: "Carousel", destination: "Carousel" },
     { title: "Grid", destination: "Grid" },

--- a/fixture/react-native/src/IssueRepro2017.tsx
+++ b/fixture/react-native/src/IssueRepro2017.tsx
@@ -1,0 +1,104 @@
+/**
+ * Reproduction for issue #2017: Duplicate sticky headers when content is placed
+ * above FlashList in the same View container.
+ *
+ * On Fabric (New Architecture), view.measureLayout(view) incorrectly returns the
+ * view's absolute position in its parent instead of (0,0). The old code subtracted
+ * this from firstItemOffset, causing the sticky header overlay to activate too early
+ * (before the in-list header had scrolled off screen), producing a visible duplicate.
+ *
+ * Repro: enable sticky headers and scroll down slowly — you should see only ONE
+ * header at any time. Before the fix you would see two.
+ */
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+
+interface Item {
+  type: "header" | "item";
+  label: string;
+}
+
+const SECTION_SIZE = 15;
+const NUM_SECTIONS = 10;
+
+const data: Item[] = [];
+for (let section = 0; section < NUM_SECTIONS; section++) {
+  data.push({ type: "header", label: `Section ${section + 1}` });
+  for (let item = 0; item < SECTION_SIZE; item++) {
+    data.push({
+      type: "item",
+      label: `Item ${section * SECTION_SIZE + item + 1}`,
+    });
+  }
+}
+
+const stickyHeaderIndices = data
+  .map((item, index) => (item.type === "header" ? index : null))
+  .filter((i): i is number => i !== null);
+
+const renderItem = ({ item }: { item: Item }) =>
+  item.type === "header" ? (
+    <View style={styles.header}>
+      <Text style={styles.headerText}>{item.label}</Text>
+    </View>
+  ) : (
+    <View style={styles.item}>
+      <Text>{item.label}</Text>
+    </View>
+  );
+
+export default function IssueRepro2017() {
+  return (
+    <View style={styles.root}>
+      {/* This banner above FlashList is what triggers the Fabric bug.
+          Without the fix, the sticky header activates too early because
+          measureParentSize returns a non-zero y on Fabric. */}
+      <View style={styles.banner}>
+        <Text style={styles.bannerText}>
+          Content above FlashList (triggers #2017)
+        </Text>
+      </View>
+
+      {/* No extra wrapping View needed — the fix makes this work correctly */}
+      <FlashList
+        data={data}
+        renderItem={renderItem}
+        estimatedItemSize={44}
+        stickyHeaderIndices={stickyHeaderIndices}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  banner: {
+    backgroundColor: "#FF6B6B",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  bannerText: {
+    color: "#fff",
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  header: {
+    height: 44,
+    backgroundColor: "#FFAB40",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+  },
+  headerText: {
+    fontWeight: "700",
+  },
+  item: {
+    height: 44,
+    justifyContent: "center",
+    paddingHorizontal: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#ccc",
+  },
+});

--- a/fixture/react-native/src/NavigationTree.tsx
+++ b/fixture/react-native/src/NavigationTree.tsx
@@ -32,6 +32,7 @@ import LotOfItems from "./lot-of-items/LotOfItems";
 import ManualBenchmarkExample from "./ManualBenchmarkExample";
 import ManualFlatListBenchmarkExample from "./ManualFlatListBenchmarkExample";
 import { StickyHeaderExample } from "./StickyHeaderExample";
+import IssueRepro2017 from "./IssueRepro2017";
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -111,6 +112,11 @@ const NavigationTree = () => {
             name="StickyHeaderExample"
             component={StickyHeaderExample}
             options={{ title: "Sticky Headers" }}
+          />
+          <Stack.Screen
+            name="IssueRepro2017"
+            component={IssueRepro2017}
+            options={{ title: "Issue #2017: Duplicate Sticky Headers" }}
           />
         </Stack.Group>
         <Stack.Screen name="Masonry" component={Masonry} />

--- a/fixture/react-native/src/constants.ts
+++ b/fixture/react-native/src/constants.ts
@@ -36,4 +36,5 @@ export type RootStackParamList = {
   ManualBenchmarkExample: undefined;
   ManualFlatListBenchmarkExample: undefined;
   StickyHeaderExample: undefined;
+  IssueRepro2017: undefined;
 };

--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -157,29 +157,32 @@ const RecyclerViewComponent = <T,>(
    */
   useLayoutEffect(() => {
     if (internalViewRef.current && firstChildViewRef.current) {
-      // Measure the outer and inner container layouts
-      const outerViewLayout = measureParentSize(internalViewRef.current);
+      // Measure the outer container size and inner container layout
+      const outerViewSize = measureParentSize(internalViewRef.current);
       const firstChildViewLayout = measureFirstChildLayout(
         firstChildViewRef.current,
         internalViewRef.current
       );
 
-      containerViewSizeRef.current = outerViewLayout;
+      containerViewSizeRef.current = outerViewSize;
 
-      // Calculate offset of first item
+      // firstChildViewLayout is already relative to the outer container,
+      // so its x/y directly gives the first item offset.
+      // We do NOT subtract outerViewSize.x/y here: measureParentSize uses
+      // view.measureLayout(view) which on Fabric incorrectly returns the view's
+      // position in its parent rather than (0,0), which would corrupt firstItemOffset
+      // when content is placed above FlashList (see issue #2017).
       const firstItemOffset = horizontal
-        ? firstChildViewLayout.x - outerViewLayout.x
-        : firstChildViewLayout.y - outerViewLayout.y;
+        ? firstChildViewLayout.x
+        : firstChildViewLayout.y;
 
       // Update the RecyclerView manager with window dimensions
       recyclerViewManager.updateLayoutParams(
         {
-          width: horizontal
-            ? outerViewLayout.width
-            : firstChildViewLayout.width,
+          width: horizontal ? outerViewSize.width : firstChildViewLayout.width,
           height: horizontal
             ? firstChildViewLayout.height
-            : outerViewLayout.height,
+            : outerViewSize.height,
         },
         isHorizontalRTL && recyclerViewManager.hasLayout()
           ? firstItemOffset -

--- a/src/recyclerview/utils/measureLayout.ts
+++ b/src/recyclerview/utils/measureLayout.ts
@@ -7,6 +7,11 @@ interface Layout {
   height: number;
 }
 
+interface Size {
+  width: number;
+  height: number;
+}
+
 /**
  * Measures the layout of a view relative to itselft.
  * Using measure wasn't returing accurate values but this workaround does.
@@ -90,13 +95,17 @@ export function roundOffPixel(value: number): number {
 
 /**
  * Specific method for easier mocking
- * Measures the layout of parent of RecyclerView
- * Returns the x, y coordinates and dimensions of the view.
+ * Measures the size of the RecyclerView's outer container.
+ * Uses a self-relative measureLayout call to get width/height synchronously.
+ * x/y are intentionally discarded: on Fabric, view.measureLayout(view) incorrectly
+ * returns the view's position in its parent instead of (0,0), which would corrupt
+ * firstItemOffset when content is placed above FlashList.
  * @param view - The React Native View component to measure
- * @returns An object containing x, y, width, and height measurements
+ * @returns An object containing width and height
  */
-export function measureParentSize(view: View): Layout {
-  return measureLayout(view, undefined);
+export function measureParentSize(view: View): Size {
+  const layout = measureLayout(view, undefined);
+  return { width: layout.width, height: layout.height };
 }
 
 /**

--- a/src/recyclerview/utils/measureLayout.web.ts
+++ b/src/recyclerview/utils/measureLayout.web.ts
@@ -5,6 +5,11 @@ interface Layout {
   height: number;
 }
 
+interface Size {
+  width: number;
+  height: number;
+}
+
 /**
  * Gets scroll offsets from up to 3 parent elements
  */
@@ -43,12 +48,10 @@ export function roundOffPixel(value: number): number {
 }
 
 /**
- * Measures the layout of parent of RecyclerView
+ * Measures the size of the RecyclerView's outer container.
  */
-export function measureParentSize(view: Element): Layout {
+export function measureParentSize(view: Element): Size {
   return {
-    x: 0,
-    y: 0,
     width: view.clientWidth,
     height: view.clientHeight,
   };


### PR DESCRIPTION
## Description

On Fabric (New Architecture), `view.measureLayout(view, callback)` incorrectly returns the view's position in its parent instead of `(0, 0)`. The old `firstItemOffset` calculation subtracted `outerViewLayout.x/y` from `firstChildViewLayout.x/y`, which was a no-op on Paper/web but **corrupted `firstItemOffset` on Fabric** when any content was placed above FlashList in the same container.

A wrong (negative) `firstItemOffset` causes the scroll manager to think the list is already scrolled at position 0, activating the sticky overlay before the in-list header has scrolled off screen — producing a visible duplicate.

**Fix:** `firstChildViewLayout` is already measured *relative to* the outer container, so its `x/y` directly gives the first item offset with no subtraction needed. `measureParentSize` now returns only `{width, height}` to make the intent explicit and prevent future misuse.

Fixes #2017

## Reviewers' hat-rack :tophat:

- `measureLayout.ts` / `measureLayout.web.ts` — `measureParentSize` return type narrowed from `Layout` to `Size`
- `RecyclerView.tsx` (lines ~160–190) — `firstItemOffset` calculation simplified; `outerViewLayout` → `outerViewSize`
- `RecyclerView.test.tsx` — 3 new regression tests simulating Fabric by mocking `measureParentSize` with non-zero `y`
- `fixture/react-native/src/IssueRepro2017.tsx` — minimal repro: red banner above FlashList + sticky sections

## Screenshots

**iOS — scrolled through sections with content above FlashList:**
Only one "Section N" header visible at a time (no duplicate). The red banner confirming the trigger condition is present throughout.

## Test plan
- [x] Repro screen `Issue #2017: Duplicate Sticky Headers` visible in fixture Examples list
- [x] On iOS simulator: scrolling through sections shows exactly one sticky header at a time
- [x] 3 new regression tests pass — simulate Fabric `measureParentSize` returning non-zero `y` at 0px, 50px, and 100px offsets
- [x] All 165 unit tests pass (`yarn test`)
- [x] TypeScript clean (`yarn type-check`)
- [x] Lint clean (`yarn lint`)