### PR TITLE
chore: update skills with testing methodology learnings

### DIFF
--- a/.claude/skills/fix-github-issue/SKILL.md
+++ b/.claude/skills/fix-github-issue/SKILL.md
@@ -340,7 +340,10 @@ Only raise the PR when explicitly asked by the user.
 - **Metro port conflict** — default port 8081 may be used by another project. Kill the other Metro, then restart on 8081 from `fixture/react-native/`. See the Metro section above.
 - **React Native version mismatch** — the native build (0.79.x) must connect to the fixture's own Metro, not another project's bundler running a different RN version.
 
-For testing/debugging pitfalls (build before test, console.log, RTL setup, agent-device swipe), see the **`review-and-test` skill**.
+- **`dist/` is NOT rebuilt on branch switch** — you MUST `yarn build` after every `git checkout`. Verify with `grep` in `dist/` that the expected code change is present. Without this, you test stale code and get false results.
+- **Always reproduce the bug on `main` BEFORE testing the fix** — without confirming the bug exists on the base branch, you can't prove the fix works. See `review-and-test` skill → "Review Methodology".
+
+For more testing/debugging pitfalls (console.log, RTL setup, agent-device swipe, observable callbacks), see the **`review-and-test` skill**.
 
 ---
 

--- a/.claude/skills/raise-pr/SKILL.md
+++ b/.claude/skills/raise-pr/SKILL.md
@@ -7,9 +7,10 @@ description: Create a GitHub PR for FlashList. Ensures no AI/Claude attribution 
 
 ## Rules
 
-1. **NEVER mention Claude, AI, or any AI tool** in commit messages, PR title, PR body, or comments. No `Co-Authored-By` AI lines. The PR must read as if written entirely by a human.
-2. **Only raise a PR when explicitly asked** by the user.
-3. **All checks must pass first**: `yarn test`, `yarn type-check`, `yarn lint`.
+1. **NEVER push directly to `main`** — always create a branch and open a PR.
+2. **NEVER mention Claude, AI, or any AI tool** in commit messages, PR title, PR body, or comments. No `Co-Authored-By` AI lines. The PR must read as if written entirely by a human.
+3. **Only raise a PR when explicitly asked** by the user.
+4. **All checks must pass first**: `yarn test`, `yarn type-check`, `yarn lint`.
 
 ---
 


### PR DESCRIPTION
## Description

Updates the `review-and-test` and `fix-github-issue` skills with learnings from recent PR review sessions.

Key additions:
- **dist/ rebuild pitfall**: `dist/` is not rebuilt on branch switch — must `yarn build` after every `git checkout` and verify with `grep` in dist
- **Review methodology**: always reproduce on `main` first, then verify on the PR branch
- **Observable callbacks**: use visible counters (useState + colored badge) to test callback-based behavior like `onStartReached`
- **Masonry sorting warning**: flag `Array.sort()` in scroll-path code as a performance concern

## Test plan
- [ ] Skills load correctly in Claude Code sessions
- [ ] No source code changes — skills only