### PR TITLE
chore: update skill instructions for metro port, app install, and e2e

### DIFF
--- a/.claude/skills/fix-github-issue/SKILL.md
+++ b/.claude/skills/fix-github-issue/SKILL.md
@@ -26,63 +26,38 @@ These are hard rules. Violating any of them is a failure.
 
 ## Running Metro
 
-Default Metro port for this project is **8081**. Start Metro explicitly on this port.
-
-### Find what's using port 8081
+Metro port is **8087**. Start from `fixture/react-native/`:
 
 ```bash
-lsof -ti :8081
+cd fixture/react-native && yarn start --port 8087
 ```
 
-If it returns a PID, either kill it or pick a different port:
+Verify: `curl -s http://localhost:8087/status`
+
+## Building & Installing the Fixture App
+
+**Only build the native app if it's not already installed.** Check first:
 
 ```bash
-# Kill whatever is on 8081
-kill -9 $(lsof -ti :8081)
+xcrun simctl get_app_container booted org.reactjs.native.example.FlatListPro 2>/dev/null
 ```
 
-### Start Metro on port 8081
-
-From `fixture/react-native/`:
+- If it **succeeds**: app is installed. Just `yarn build` (TS) and relaunch.
+- If it **fails**: app is not installed. Build and install:
 
 ```bash
-yarn react-native start --port 8081
+cd fixture/react-native && yarn react-native run-ios
 ```
 
-Or from the repo root:
+## E2E Tests
+
+**If you add or modify any e2e tests (files matching `*.e2e.*`)**, you MUST run them and verify they pass before raising a PR:
 
 ```bash
-cd fixture/react-native && yarn start --port 8081
+yarn e2e:ios
 ```
 
-### Tell the simulator to use port 8081
-
-**iOS** — pass the port when building/running:
-
-```bash
-cd fixture/react-native && yarn react-native run-ios --port 8081
-```
-
-**Android** — reverse the port via ADB so the emulator can reach Metro on your machine:
-
-```bash
-adb reverse tcp:8081 tcp:8081
-cd fixture/react-native && yarn react-native run-android --port 8081
-```
-
-### In-app Dev Menu (already running app)
-
-If the app is already installed and running, reload it against the new port without rebuilding:
-
-- **iOS simulator**: `Cmd+D` → "Configure Bundler" → set host `localhost` and port `8081`
-- **Android emulator**: shake or `Cmd+M` → "Configure Bundler" → set host `10.0.2.2` and port `8081`
-
-### Verify Metro is reachable
-
-```bash
-curl -s http://localhost:8081/status
-# Should return: {"status":"packager-status:running"}
-```
+This runs `detox build -c ios.sim.release` followed by `detox test -c ios.sim.release`. E2e test files live in `fixture/react-native/e2e/tests/`.
 
 ## Common Pitfalls
 
@@ -92,7 +67,8 @@ curl -s http://localhost:8081/status
 - **Stale layout cache** — if sizes look wrong after a fix, call `ref.current?.clearLayoutCacheOnUpdate()`
 - **Prop not forwarded** — check `FlashListProps.ts` and `RecyclerView.tsx` to confirm the prop reaches the layout manager
 - **Grid row detection with spans** — never use `Math.floor(index / numColumns)` to determine which row an item is in when `overrideItemLayout` spans are possible. Instead, compare `layout.y` values from the layout manager — items in the same row always share the same `y`.
-- **Metro port conflict** — this project uses port 8081. Kill anything on that port, then restart Metro from `fixture/react-native/`. See the Metro section above.
+- **Metro port conflict** — this project uses port 8087. Kill anything on that port, then restart Metro from `fixture/react-native/`. See the Metro section above.
+- **App can't connect to Metro** — if the app shows a red/yellow error about connecting to the bundler, configure the port: iOS simulator `Cmd+D` → "Configure Bundler" → set host `localhost` and port `8087`. Then reload.
 - **React Native version mismatch** — the native build (0.84.x) must connect to the fixture's own Metro, not another project's bundler running a different RN version.
 
 - **`dist/` is NOT rebuilt on branch switch** — you MUST `yarn build` after every `git checkout`. Verify with `grep` in `dist/` that the expected code change is present. Without this, you test stale code and get false results.

--- a/.claude/skills/review-and-test/SKILL.md
+++ b/.claude/skills/review-and-test/SKILL.md
@@ -11,9 +11,9 @@ description: Review a FlashList PR or branch, run unit tests, test on iOS simula
 which agent-device && which gh && yarn test --version
 ```
 
-Ensure Metro is running on port 8081 from `fixture/react-native/`:
+Ensure Metro is running on port 8087 from `fixture/react-native/`:
 ```bash
-curl -s http://localhost:8081/status
+curl -s http://localhost:8087/status
 ```
 
 ---
@@ -52,6 +52,20 @@ yarn type-check
 yarn lint
 ```
 
+### E2E Tests
+
+**If any e2e tests were added or modified in the PR/branch**, you MUST run them and verify they pass:
+
+```bash
+# Check if e2e tests were changed
+git diff main...HEAD --name-only | grep '\.e2e\.'
+
+# If yes, run e2e tests on iOS
+yarn e2e:ios
+```
+
+E2e tests use Detox. They require the fixture app to be built in release mode (`detox build -c ios.sim.release`) and then run (`detox test -c ios.sim.release`). The `yarn e2e:ios` script handles both steps.
+
 If tests fail, investigate before proceeding to device testing.
 
 ---
@@ -64,7 +78,25 @@ If tests fail, investigate before proceeding to device testing.
 yarn build   # runs tsc -b
 ```
 
-After building, **relaunch the app** (kill + reopen) so Metro serves the new bundle:
+### Install the fixture app only if needed
+
+Before building the native app, check if it's already installed on the simulator. **Only build if it's not installed:**
+
+```bash
+# Check if app is already installed
+xcrun simctl get_app_container booted org.reactjs.native.example.FlatListPro 2>/dev/null
+```
+
+- If the command **succeeds** (returns a path): the app is installed. Skip `run-ios` — just relaunch it.
+- If the command **fails**: the app is not installed. Build and install it:
+
+```bash
+cd fixture/react-native && yarn react-native run-ios
+```
+
+### Relaunch the app
+
+After `yarn build`, **relaunch the app** (kill + reopen) so Metro serves the new bundle:
 
 ```bash
 agent-device close --platform ios
@@ -267,10 +299,11 @@ Run through relevant entries after any fix or review. This is the single source 
 - **RTL looks wrong but LTR is fine** — did you set `forceRTL(true)` in `index.js` and do a full kill+relaunch?
 - **`agent-device swipe` gives "drag" error** — delete `~/.agent-device/ios-runner/derived/` and re-run `agent-device open` to rebuild the iOS runner
 - **No console output in Metro** — use the HTTP server approach (see Step 6)
-- **Metro log location** — `lsof -p $(lsof -ti :8081) | grep "1w"` to find where Metro stdout goes (often `/private/tmp/metro_fixture.log`)
+- **Metro log location** — `lsof -p $(lsof -ti :8087) | grep "1w"` to find where Metro stdout goes (often `/private/tmp/metro_fixture.log`)
 - **RTL horizontal scroll direction is reversed** — to scroll toward the logical START (header/Item 0), swipe right-to-left: `agent-device swipe 350 256 50 256`. To scroll toward higher items, swipe left-to-right.
 - **Fixture app bundle ID** — `org.reactjs.native.example.FlatListPro`. Use with `xcrun simctl launch`.
 - **`estimatedItemSize` does not exist** — this FlashList does NOT have this prop. Do not use it.
+- **App can't connect to Metro** — if the app shows a red/yellow error about connecting to the bundler, configure the port: iOS simulator `Cmd+D` → "Configure Bundler" → set host `localhost` and port `8087`. Then reload.
 - **agent-device navigation** — use ONLY `screenshot` + `press` (percentage method). `snapshot`, `find`, and `click` commands are prohibited. Downsample screenshots with `sips --resampleHeight 852` before reading. See the `agent-device` skill for the full coordinate mapping reference.
 
 ---


### PR DESCRIPTION
## Description

Updates the `fix-github-issue` and `review-and-test` skill files with three improvements:

1. **Metro port 8087** — all references updated from 8081 to 8087 to match actual dev setup
2. **Skip native build if app installed** — checks `xcrun simctl get_app_container` before running `run-ios`, avoiding unnecessary rebuilds
3. **E2e test enforcement** — when e2e test files (`*.e2e.*`) are added or modified, they must be run and pass before raising a PR
4. **Metro connection troubleshooting** — added fallback tip to configure bundler port via Dev Menu if app can't connect

Also simplified the Metro section in `fix-github-issue` to remove redundant setup instructions.

## Reviewers' hat-rack :tophat:

These are internal skill files (`.claude/skills/`). No runtime code changes.

## Test plan
- [ ] Read through both updated skill files for accuracy
- [ ] Verify port 8087 is consistent across all references