### PR TITLE
fix(scroll): maintain visible position when prepending large items

### DIFF
--- a/fixture/react-native/src/ExamplesScreen.tsx
+++ b/fixture/react-native/src/ExamplesScreen.tsx
@@ -123,6 +123,10 @@ export const ExamplesScreen = () => {
       title: "Grid with Separator",
       destination: "GridWithSeparator",
     },
+    {
+      title: "Prepend Scroll Test",
+      destination: "PrependScrollTest",
+    },
   ];
   return (
     <>

--- a/fixture/react-native/src/NavigationTree.tsx
+++ b/fixture/react-native/src/NavigationTree.tsx
@@ -35,6 +35,7 @@ import ManualBenchmarkExample from "./ManualBenchmarkExample";
 import ManualFlatListBenchmarkExample from "./ManualFlatListBenchmarkExample";
 import { StickyHeaderExample } from "./StickyHeaderExample";
 import { GridWithSeparator } from "./GridWithSeparator";
+import PrependScrollTest from "./PrependScrollTest";
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -148,6 +149,11 @@ const NavigationTree = () => {
           name="ManualFlatListBenchmarkExample"
           component={ManualFlatListBenchmarkExample}
           options={{ title: "Manual Flat List Benchmark Example" }}
+        />
+        <Stack.Screen
+          name="PrependScrollTest"
+          component={PrependScrollTest}
+          options={{ title: "Prepend Scroll Test" }}
         />
         <Stack.Group screenOptions={{ presentation: "modal" }}>
           <Stack.Screen name="Debug" component={DebugScreen} />

--- a/fixture/react-native/src/PrependScrollTest.tsx
+++ b/fixture/react-native/src/PrependScrollTest.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from "react";
+import { Button, StyleSheet, Text, View } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+
+interface Item {
+  index: number;
+  height: number;
+}
+
+const drawDistance = 250;
+const viewHeight = 501;
+const lastHeight = viewHeight;
+const beforeLastHeight = 351 + (7 * viewHeight + lastHeight) / 5;
+const sumOfFirstTwoHeights = 501 + viewHeight;
+
+const items: Item[] = [
+  { index: 0, height: sumOfFirstTwoHeights },
+  { index: 1, height: 0 },
+  { index: 2, height: beforeLastHeight },
+  { index: 3, height: lastHeight },
+];
+
+const PrependScrollList = ({
+  height,
+  allItems,
+}: {
+  height: number;
+  allItems: Item[];
+}) => {
+  const [firstVisibleIndex, setFirstVisibleIndex] = useState(() => {
+    return Math.max(allItems.length - 1, 0);
+  });
+
+  const visibleItems =
+    firstVisibleIndex > 0 ? allItems.slice(firstVisibleIndex) : allItems;
+  const prependAllItems = () => setFirstVisibleIndex(0);
+
+  useEffect(() => {
+    const timer = setTimeout(prependAllItems, 300);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <View style={{ height }}>
+      <FlashList
+        drawDistance={drawDistance}
+        data={visibleItems}
+        keyExtractor={(item) => item.index.toString()}
+        renderItem={({ item }) => (
+          <View
+            style={{
+              height: item.height,
+              backgroundColor:
+                item.index === 3
+                  ? "green"
+                  : item.index % 2 === 0
+                  ? "red"
+                  : "orange",
+            }}
+          >
+            <Text style={styles.text}>
+              Item {item.index} ({item.height}px)
+            </Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+};
+
+const PrependScrollTest = () => {
+  const [key, setKey] = useState(false);
+  return (
+    <View style={styles.container}>
+      <Button title="Reset" onPress={() => setKey(!key)} />
+      <Text style={styles.info}>
+        Green item (initial) should stay visible after prepend
+      </Text>
+      <PrependScrollList key={`${key}`} height={viewHeight} allItems={items} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  info: {
+    padding: 8,
+    fontSize: 14,
+    textAlign: "center",
+  },
+  text: {
+    fontSize: 18,
+    lineHeight: 28,
+    color: "white",
+    padding: 8,
+  },
+});
+
+export default PrependScrollTest;

--- a/fixture/react-native/src/constants.ts
+++ b/fixture/react-native/src/constants.ts
@@ -39,4 +39,5 @@ export type RootStackParamList = {
   ManualFlatListBenchmarkExample: undefined;
   StickyHeaderExample: undefined;
   GridWithSeparator: undefined;
+  PrependScrollTest: undefined;
 };

--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -58,6 +58,12 @@ export function useRecyclerViewController<T>(
   const firstVisibleItemKey = useRef<string | undefined>(undefined);
   const firstVisibleItemLayout = useRef<RVLayout | undefined>(undefined);
 
+  // Set to true when an offset correction is applied based on estimated
+  // (unmeasured) item layouts. Subsequent render passes will refine the
+  // correction as items get measured, and need to update the internal
+  // scroll offset to keep engaged indices in sync.
+  const isRefiningCorrection = useRef(false);
+
   // Queue to store callbacks that should be executed after scroll offset updates
   const pendingScrollCallbacks = useRef<(() => void)[]>([]);
 
@@ -134,6 +140,12 @@ export function useRecyclerViewController<T>(
       recyclerViewManager.shouldMaintainVisibleContentPosition()
     ) {
       const hasDataChanged = currentDataLength !== lastDataLengthRef.current;
+      // Snapshot and reset so the ref only stays true when THIS pass actively
+      // applies a correction. If diff is 0 this pass, it resets to false and
+      // tracking updates normally.
+      const wasRefining = isRefiningCorrection.current;
+      isRefiningCorrection.current = false;
+
       // If we have a tracked first visible item, maintain its position
       if (firstVisibleItemKey.current) {
         const currentIndexOfFirstVisibleItem =
@@ -144,9 +156,9 @@ export function useRecyclerViewController<T>(
                 recyclerViewManager.getDataKey(index) ===
                 firstVisibleItemKey.current
             ) ??
-          (hasDataChanged
+          (hasDataChanged || wasRefining
             ? data?.findIndex(
-                (item, index) =>
+                (_item, index) =>
                   recyclerViewManager.getDataKey(index) ===
                   firstVisibleItemKey.current
               )
@@ -170,9 +182,7 @@ export function useRecyclerViewController<T>(
             !pauseOffsetCorrection.current &&
             !recyclerViewManager.animationOptimizationsEnabled
           ) {
-            // console.log("diff", diff, firstVisibleItemKey.current);
             if (PlatformConfig.supportsOffsetCorrection) {
-              // console.log("scrollBy", diff);
               scrollAnchorRef.current?.scrollBy(diff);
             } else {
               const scrollToParams = horizontal
@@ -186,7 +196,11 @@ export function useRecyclerViewController<T>(
                   };
               scrollViewRef.current?.scrollTo(scrollToParams);
             }
-            if (hasDataChanged) {
+            // Update internal scroll offset when data changed or during any
+            // phase of a multi-pass refinement, so the engaged indices stay
+            // in sync with the corrected scroll position as items get measured.
+            if (hasDataChanged || wasRefining) {
+              isRefiningCorrection.current = true;
               updateScrollOffsetWithCallback(
                 recyclerViewManager.getAbsoluteLastScrollOffset() + diff,
                 () => {}
@@ -200,7 +214,12 @@ export function useRecyclerViewController<T>(
         }
       }
 
-      computeFirstVisibleIndexForOffsetCorrection();
+      // Keep tracking the same item while refinement is active so subsequent
+      // passes can apply further corrections as items get measured.
+      // Refinement ends naturally when diff converges to 0 and the ref resets.
+      if (!isRefiningCorrection.current) {
+        computeFirstVisibleIndexForOffsetCorrection();
+      }
     }
     lastDataLengthRef.current = recyclerViewManager.getDataLength();
   }, [


### PR DESCRIPTION
## Description

When items are prepended to a list with `maintainVisibleContentPosition`, the scroll correction can be inaccurate because items above the tracked anchor item haven't been measured yet — their estimated heights produce a wrong diff. The original code then immediately reset the anchor tracking after applying the inaccurate correction, preventing any refinement.

The fix introduces an `isRefiningCorrection` ref that keeps the anchor item stable across render passes while a correction is in progress. Each pass applies an incremental correction as more items get measured, and terminates naturally when the diff converges to 0.

Also adds a `PrependScrollTest` fixture screen (from the issue reproduction steps) to verify the fix.

Fixes #2136

## Reviewers' hat-rack :tophat:

- Focus on `applyOffsetCorrection` in `useRecyclerViewController.tsx` — specifically the `wasRefining` snapshot pattern and when `computeFirstVisibleIndexForOffsetCorrection` is/isn't called
- Edge case: what happens when `diff !== 0` but `hasDataChanged` is false and `wasRefining` is false (e.g. normal scroll) — the correction path is still taken via `scrollBy`/`scrollTo` but `isRefiningCorrection` is not set, so tracking resets normally

## Screenshots or videos

**Before**: after prepend, the viewport jumps to show the newly prepended (red) items instead of keeping the original (green) item visible.

**After**: the green initial item stays visible after prepend and after Reset.

## Test plan
- [x] Unit tests pass (`yarn test`)
- [x] Type check passes (`yarn type-check`)
- [x] Lint passes (`yarn lint`)
- [x] Verified on iOS simulator (iPhone 17) — green item stays visible after prepend and after Reset
- [x] No regressions on related screens