### PR TITLE
fix(scroll): guard against zero window size in bound detection

### DIFF
--- a/src/recyclerview/hooks/useBoundDetection.ts
+++ b/src/recyclerview/hooks/useBoundDetection.ts
@@ -84,6 +84,14 @@ export function useBoundDetection<T>(
         (isHorizontal ? contentSize.width : contentSize.height) +
         recyclerViewManager.firstItemOffset;
 
+      // Skip bound detection if the window has no measurable size.
+      // This can happen when the list is mounted off-screen (e.g., in a
+      // background tab) and all measurements come back as 0, which would
+      // incorrectly trigger onEndReached/onStartReached.
+      if (visibleLength <= 0) {
+        return;
+      }
+
       // Check if we're near the end of the list
       if (onEndReached) {
         const onEndReachedThreshold = onEndReachedThresholdProp ?? 0.5;


### PR DESCRIPTION
## Summary
- Adds a `visibleLength <= 0` early return in `useBoundDetection` to skip `onEndReached`/`onStartReached` when the list has no measurable size
- Prevents infinite loading when the list is mounted off-screen (e.g., background tab) where all measurements are 0

Fixes #1956

## Test plan
- [x] Verify `onEndReached` no longer fires when list is mounted in a background/hidden tab
- [x] Verify `onEndReached` still fires correctly during normal scrolling
- [x] Unit tests pass (`yarn test`)