### PR TITLE
feat(ci): add agent feedback artifact upload

### DIFF
--- a/.github/workflows/agent-android-bot.yml
+++ b/.github/workflows/agent-android-bot.yml
@@ -154,5 +154,13 @@ jobs:
           claude_args: >-
             --model claude-opus-4-6
             --allowedTools "${{ env.ALLOWED_TOOLS }}"
-            --append-system-prompt "You are running on CI (GitHub Actions). Environment: Ubuntu runner with Android emulator running (device Android35). No iOS simulator. Use agent-device with --platform android --session droid. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081)."
+            --append-system-prompt "You are running on CI (GitHub Actions). Environment: Ubuntu runner with Android emulator running (device Android35). No iOS simulator. Use agent-device with --platform android --session droid. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081). When done, write a brief feedback file to /tmp/agent-feedback.md covering: what you accomplished, tools you needed but couldn't use, issues with skill instructions, suggestions for improvement."
           prompt: ${{ github.event.inputs.prompt || '' }}
+
+      - name: Upload agent feedback
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: agent-feedback-android-bot-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+          path: /tmp/agent-feedback.md
+          if-no-files-found: ignore

--- a/.github/workflows/agent-bot.yml
+++ b/.github/workflows/agent-bot.yml
@@ -78,5 +78,13 @@ jobs:
           claude_args: >-
             --model claude-opus-4-6
             --allowedTools "${{ env.ALLOWED_TOOLS }}"
-            --append-system-prompt "You are running on CI (GitHub Actions). Environment: macOS runner with Xcode and iOS simulator. No Android emulator. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081)."
+            --append-system-prompt "You are running on CI (GitHub Actions). Environment: macOS runner with Xcode and iOS simulator. No Android emulator. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081). When done, write a brief feedback file to /tmp/agent-feedback.md covering: what you accomplished, tools you needed but couldn't use, issues with skill instructions, suggestions for improvement."
           prompt: ${{ github.event.inputs.prompt || '' }}
+
+      - name: Upload agent feedback
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: agent-feedback-bot-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+          path: /tmp/agent-feedback.md
+          if-no-files-found: ignore

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -79,3 +79,17 @@ jobs:
             Fix this GitHub issue. Read and follow .claude/skills/fix-github-issue/SKILL.md for the full workflow.
             After fixing, read and follow .claude/skills/raise-pr/SKILL.md to raise a PR.
             CI notes: use default Metro port (8081).
+
+            When done (whether successful or not), write a brief feedback file to /tmp/agent-feedback.md with:
+            - What you accomplished (or where you got stuck)
+            - Any tools you needed but couldn't use
+            - Any issues with the skill instructions
+            - Suggestions for improvement
+
+      - name: Upload agent feedback
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: agent-feedback-fix-${{ github.event.issue.number || github.run_id }}
+          path: /tmp/agent-feedback.md
+          if-no-files-found: ignore

--- a/.github/workflows/agent-triage.yml
+++ b/.github/workflows/agent-triage.yml
@@ -34,3 +34,17 @@ jobs:
           prompt: |
             You are running on CI (GitHub Actions).
             Read the skill file at .claude/skills/triage-issue/SKILL.md and follow its instructions to triage this issue.
+
+            When done, write a brief feedback file to /tmp/agent-feedback.md with:
+            - What you accomplished
+            - Any tools you needed but couldn't use
+            - Any issues with the skill instructions
+            - Suggestions for improvement
+
+      - name: Upload agent feedback
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: agent-feedback-triage-${{ github.event.issue.number }}
+          path: /tmp/agent-feedback.md
+          if-no-files-found: ignore


### PR DESCRIPTION
## Description

Adds self-reflection feedback to all four agent workflows. After each run, the agent writes a brief feedback file covering what worked, what didn't, missing tools, and suggestions. The file is uploaded as a GitHub Actions artifact for review.

## Reviewers' hat-rack :tophat:

- Check that feedback prompts don't leak secrets (they ask for tool/workflow feedback, not env vars)
- Artifact names include issue/PR number for easy identification

## Test plan
- [x] Feedback prompt added to all 4 workflows (triage, fix, bot, android-bot)
- [x] Upload step uses `if: always()` + `if-no-files-found: ignore`
- [x] Artifact names are unique per run