### PR TITLE
fix(ci): correct allowedTools syntax for claude-code-action v1

### DIFF
--- a/.github/workflows/agent-android-bot.yml
+++ b/.github/workflows/agent-android-bot.yml
@@ -22,20 +22,20 @@ permissions:
 env:
   ALLOWED_TOOLS: >-
     Read,Edit,Write,Glob,Grep,
-    Bash(yarn:install:*),Bash(yarn:build:*),Bash(yarn:test:*),Bash(yarn:type-check:*),Bash(yarn:lint:*),Bash(yarn:start:*),Bash(yarn:e2e:*),Bash(yarn:react-native:*),
-    Bash(git:log:*),Bash(git:diff:*),Bash(git:status:*),Bash(git:show:*),
-    Bash(git:checkout:*),Bash(git:add:*),Bash(git:commit:*),Bash(git:push -u:*),
-    Bash(git:branch:*),Bash(git:rev-parse:*),Bash(git:fetch:*),
-    Bash(gh:issue:*),Bash(gh:pr:*),Bash(gh:label:*),
-    Bash(agent-device:*),
-    Bash(adb:devices:*),Bash(adb:wait-for-device:*),Bash(adb:install:*),Bash(adb:reverse:*),
-    Bash(adb:shell getprop:*),Bash(adb:shell am:*),Bash(adb:shell pm:*),Bash(adb:shell screenrecord:*),
-    Bash(adb:pull:*),Bash(adb:shell kill:*),Bash(adb:shell pidof:*),
-    Bash(curl:-s http://localhost:*),
-    Bash(grep:*),Bash(find:*),Bash(ls:*),Bash(mkdir:*),Bash(rm:*),
-    Bash(kill:*),Bash(lsof:*),Bash(nohup:*),Bash(sleep:*),
-    Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),
-    Bash(md5sum:*),Bash(ffmpeg:*)
+    Bash(yarn install),Bash(yarn install *),Bash(yarn build),Bash(yarn build *),Bash(yarn test),Bash(yarn test *),Bash(yarn type-check),Bash(yarn lint),Bash(yarn start),Bash(yarn start *),Bash(yarn e2e:*),Bash(yarn react-native *),
+    Bash(git log),Bash(git log *),Bash(git diff),Bash(git diff *),Bash(git status),Bash(git show *),
+    Bash(git checkout *),Bash(git add *),Bash(git commit *),Bash(git push -u *),
+    Bash(git branch),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch),Bash(git fetch *),
+    Bash(gh issue *),Bash(gh pr *),Bash(gh label *),
+    Bash(agent-device *),
+    Bash(adb devices),Bash(adb wait-for-device),Bash(adb install *),Bash(adb reverse *),
+    Bash(adb shell getprop *),Bash(adb shell am *),Bash(adb shell pm *),Bash(adb shell screenrecord *),
+    Bash(adb pull *),Bash(adb shell kill *),Bash(adb shell pidof *),
+    Bash(curl -s http://localhost:*),
+    Bash(grep *),Bash(find *),Bash(ls),Bash(ls *),Bash(mkdir *),Bash(rm *),
+    Bash(kill *),Bash(lsof),Bash(lsof *),Bash(nohup *),Bash(sleep *),
+    Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),
+    Bash(md5sum *),Bash(ffmpeg *)
 
 jobs:
   bot:

--- a/.github/workflows/agent-bot.yml
+++ b/.github/workflows/agent-bot.yml
@@ -22,17 +22,17 @@ permissions:
 env:
   ALLOWED_TOOLS: >-
     Read,Edit,Write,Glob,Grep,
-    Bash(yarn:install:*),Bash(yarn:build:*),Bash(yarn:test:*),Bash(yarn:type-check:*),Bash(yarn:lint:*),Bash(yarn:start:*),Bash(yarn:e2e:*),Bash(yarn:react-native:*),Bash(bundle:exec:*),
-    Bash(git:log:*),Bash(git:diff:*),Bash(git:status:*),Bash(git:show:*),
-    Bash(git:checkout:*),Bash(git:add:*),Bash(git:commit:*),Bash(git:push -u:*),
-    Bash(git:branch:*),Bash(git:rev-parse:*),Bash(git:fetch:*),
-    Bash(gh:issue:*),Bash(gh:pr:*),Bash(gh:label:*),
-    Bash(agent-device:*),Bash(xcrun:simctl list:*),Bash(xcrun:simctl get_app_container:*),Bash(xcrun:simctl install:*),Bash(xcrun:simctl launch:*),Bash(xcrun:simctl boot:*),Bash(sips:*),
-    Bash(curl:-s http://localhost:*),
-    Bash(grep:*),Bash(find:*),Bash(ls:*),Bash(mkdir:*),Bash(rm:*),
-    Bash(kill:*),Bash(lsof:*),Bash(nohup:*),Bash(sleep:*),
-    Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),
-    Bash(md5sum:*),Bash(ffmpeg:*)
+    Bash(yarn install),Bash(yarn install *),Bash(yarn build),Bash(yarn build *),Bash(yarn test),Bash(yarn test *),Bash(yarn type-check),Bash(yarn lint),Bash(yarn start),Bash(yarn start *),Bash(yarn e2e:*),Bash(yarn react-native *),Bash(bundle exec *),
+    Bash(git log),Bash(git log *),Bash(git diff),Bash(git diff *),Bash(git status),Bash(git show *),
+    Bash(git checkout *),Bash(git add *),Bash(git commit *),Bash(git push -u *),
+    Bash(git branch),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch),Bash(git fetch *),
+    Bash(gh issue *),Bash(gh pr *),Bash(gh label *),
+    Bash(agent-device *),Bash(xcrun simctl list),Bash(xcrun simctl list *),Bash(xcrun simctl get_app_container *),Bash(xcrun simctl install *),Bash(xcrun simctl launch *),Bash(xcrun simctl boot *),Bash(sips *),
+    Bash(curl -s http://localhost:*),
+    Bash(grep *),Bash(find *),Bash(ls),Bash(ls *),Bash(mkdir *),Bash(rm *),
+    Bash(kill *),Bash(lsof),Bash(lsof *),Bash(nohup *),Bash(sleep *),
+    Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),
+    Bash(md5sum *),Bash(ffmpeg *)
 
 jobs:
   bot:

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -14,17 +14,17 @@ permissions:
 env:
   ALLOWED_TOOLS: >-
     Read,Edit,Write,Glob,Grep,
-    Bash(yarn:install:*),Bash(yarn:build:*),Bash(yarn:test:*),Bash(yarn:type-check:*),Bash(yarn:lint:*),Bash(yarn:start:*),Bash(yarn:e2e:*),Bash(yarn:react-native:*),Bash(bundle:exec:*),
-    Bash(git:log:*),Bash(git:diff:*),Bash(git:status:*),Bash(git:show:*),
-    Bash(git:checkout:*),Bash(git:add:*),Bash(git:commit:*),Bash(git:push -u:*),
-    Bash(git:branch:*),Bash(git:rev-parse:*),Bash(git:fetch:*),
-    Bash(gh:issue:*),Bash(gh:pr:*),Bash(gh:label:*),
-    Bash(agent-device:*),Bash(xcrun:simctl list:*),Bash(xcrun:simctl get_app_container:*),Bash(xcrun:simctl install:*),Bash(xcrun:simctl launch:*),Bash(xcrun:simctl boot:*),Bash(sips:*),
-    Bash(curl:-s http://localhost:*),
-    Bash(grep:*),Bash(find:*),Bash(ls:*),Bash(mkdir:*),Bash(rm:*),
-    Bash(kill:*),Bash(lsof:*),Bash(nohup:*),Bash(sleep:*),
-    Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),
-    Bash(md5sum:*),Bash(ffmpeg:*)
+    Bash(yarn install),Bash(yarn install *),Bash(yarn build),Bash(yarn build *),Bash(yarn test),Bash(yarn test *),Bash(yarn type-check),Bash(yarn lint),Bash(yarn start),Bash(yarn start *),Bash(yarn e2e:*),Bash(yarn react-native *),Bash(bundle exec *),
+    Bash(git log),Bash(git log *),Bash(git diff),Bash(git diff *),Bash(git status),Bash(git show *),
+    Bash(git checkout *),Bash(git add *),Bash(git commit *),Bash(git push -u *),
+    Bash(git branch),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch),Bash(git fetch *),
+    Bash(gh issue *),Bash(gh pr *),Bash(gh label *),
+    Bash(agent-device *),Bash(xcrun simctl list),Bash(xcrun simctl list *),Bash(xcrun simctl get_app_container *),Bash(xcrun simctl install *),Bash(xcrun simctl launch *),Bash(xcrun simctl boot *),Bash(sips *),
+    Bash(curl -s http://localhost:*),
+    Bash(grep *),Bash(find *),Bash(ls),Bash(ls *),Bash(mkdir *),Bash(rm *),
+    Bash(kill *),Bash(lsof),Bash(lsof *),Bash(nohup *),Bash(sleep *),
+    Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),
+    Bash(md5sum *),Bash(ffmpeg *)
 
 jobs:
   fix:

--- a/.github/workflows/agent-triage.yml
+++ b/.github/workflows/agent-triage.yml
@@ -28,6 +28,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: >-
             --model claude-sonnet-4-6
+            --allowedTools "Read,Write,Glob,Grep,Bash(gh issue *),Bash(gh label *)"
             --disallowedTools "Edit,MultiEdit"
           prompt: |
             You are running on CI (GitHub Actions).


### PR DESCRIPTION
## Description

Fixes the `allowedTools` syntax for claude-code-action v1. The v1 flag uses `Bash(command prefix)` format with `*` wildcards (e.g., `Bash(gh issue *)`), **not** the colon-separated `Bash(command:subcommand:*)` format which is for `.claude/settings.json` only.

All Bash tool permissions were silently failing, causing **100% permission denials** on every agent run — the triage bot couldn't label issues, the fix bot couldn't run yarn/git, etc.

**Before:** `Bash(gh:issue:*),Bash(yarn:build:*),Bash(git:log:*)`
**After:** `Bash(gh issue *),Bash(yarn build *),Bash(git log *)`

Also adds `--allowedTools` back to triage (was removed while debugging) and passes issue number/title in the triage prompt.

Now verified working with 0 denials.

## Reviewers' hat-rack :tophat:

- This is the root cause of all triage failures since merge
- Verify the pattern format matches claude-code-action v1 docs

## Test plan
- [ ] Triage: open a test issue, verify labels + comment appear
- [ ] Bot: comment `@agent` on an issue, verify response
