### PR TITLE
fix(ci): add cd and ./gradlew to agent allowed tools

### DIFF
--- a/.github/workflows/agent-android-bot.yml
+++ b/.github/workflows/agent-android-bot.yml
@@ -35,7 +35,8 @@ env:
     Bash(grep *),Bash(find *),Bash(ls),Bash(ls *),Bash(mkdir *),Bash(rm *),
     Bash(kill *),Bash(lsof),Bash(lsof *),Bash(nohup *),Bash(sleep *),
     Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),
-    Bash(md5sum *),Bash(ffmpeg *)
+    Bash(md5sum *),Bash(ffmpeg *),
+    Bash(cd *),Bash(./gradlew *)
 
 jobs:
   bot:

--- a/.github/workflows/agent-bot.yml
+++ b/.github/workflows/agent-bot.yml
@@ -32,7 +32,8 @@ env:
     Bash(grep *),Bash(find *),Bash(ls),Bash(ls *),Bash(mkdir *),Bash(rm *),
     Bash(kill *),Bash(lsof),Bash(lsof *),Bash(nohup *),Bash(sleep *),
     Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),
-    Bash(md5sum *),Bash(ffmpeg *)
+    Bash(md5sum *),Bash(ffmpeg *),
+    Bash(cd *),Bash(./gradlew *)
 
 jobs:
   bot:

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -24,7 +24,8 @@ env:
     Bash(grep *),Bash(find *),Bash(ls),Bash(ls *),Bash(mkdir *),Bash(rm *),
     Bash(kill *),Bash(lsof),Bash(lsof *),Bash(nohup *),Bash(sleep *),
     Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),
-    Bash(md5sum *),Bash(ffmpeg *)
+    Bash(md5sum *),Bash(ffmpeg *),
+    Bash(cd *),Bash(./gradlew *)
 
 jobs:
   fix:


### PR DESCRIPTION
## Description

Adds `Bash(cd *)` and `Bash(./gradlew *)` to allowed tools for fix, bot, and android-bot workflows. Without these, the agent can't build Android APKs or navigate directories.

- `cd` — no security risk, only changes directory for that single command
- `./gradlew` — same trust model as `yarn` (runs build scripts from the checked-out repo)

Not added to triage (read-only workflow).

## Test plan
- [ ] Android agent can run `./gradlew assembleDebug` and `cd fixture/react-native`