### PR TITLE
chore(ci): pass explicit issue number to agent-fix prompt

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -80,7 +80,11 @@ jobs:
           prompt: |
             You are running on CI (GitHub Actions). There is no human to confirm with — act autonomously.
             Environment: macOS runner with Xcode and iOS simulator. No Android emulator.
-            Fix this GitHub issue. Read and follow .claude/skills/fix-github-issue/SKILL.md for the full workflow.
+
+            YOUR ASSIGNED ISSUE: #${{ github.event.issue.number }}
+            TITLE: ${{ github.event.issue.title }}
+
+            Fix ONLY this issue — do not fix other issues. Read and follow .claude/skills/fix-github-issue/SKILL.md for the full workflow.
             After fixing, read and follow .claude/skills/raise-pr/SKILL.md to raise a PR.
             CI notes: use default Metro port (8081).
 


### PR DESCRIPTION
## Description

The agent-fix workflow prompt said "Fix this GitHub issue" without specifying which one, relying on claude-code-action to inject context automatically. In run #23455139708, the agent was assigned issue #1914 but drifted over 136 turns to fix issue #2175 instead — a completely different bug.

Now the issue number and title are passed explicitly via `${{ github.event.issue.number }}` and `${{ github.event.issue.title }}`, matching how agent-triage already works.

## Reviewers' hat-rack :tophat:

Simple template variable addition. Compare with agent-triage.yml which already does this correctly.

## Test plan
- [ ] Next agent-fix run targets the correct issue
