### PR TITLE
chore(ci): fix agent-fix issue targeting and PR token usage

### DIFF
--- a/.claude/skills/raise-pr/SKILL.md
+++ b/.claude/skills/raise-pr/SKILL.md
@@ -127,7 +127,7 @@ GH_TOKEN="$AGENT_PR_TOKEN" gh pr create \
 
 > **CRITICAL — TOKEN VERIFICATION (read this before running `gh pr create`)**
 >
-> 1. First, verify the token is available: `echo "AGENT_PR_TOKEN is set: ${AGENT_PR_TOKEN:+yes}"` — if it prints "yes", proceed.
+> 1. First, verify the token is available: `[ -n "$AGENT_PR_TOKEN" ] && echo "token ok" || echo "TOKEN MISSING"` — do NOT echo the token value itself.
 > 2. You **MUST** use `GH_TOKEN="$AGENT_PR_TOKEN" gh pr create ...` — never bare `gh pr create`.
 > 3. PRs created with the default `GITHUB_TOKEN` show as `app/github-actions` and **cannot be merged**.
 > 4. After creating the PR, verify the author: `gh pr view --json author --jq '.author.login'` — it must NOT be `app/github-actions`.

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -80,7 +80,11 @@ jobs:
           prompt: |
             You are running on CI (GitHub Actions). There is no human to confirm with — act autonomously.
             Environment: macOS runner with Xcode and iOS simulator. No Android emulator.
-            Fix this GitHub issue. Read and follow .claude/skills/fix-github-issue/SKILL.md for the full workflow.
+
+            YOUR ASSIGNED ISSUE: #${{ github.event.issue.number }}
+            TITLE: ${{ github.event.issue.title }}
+
+            Fix ONLY this issue — do not fix other issues. Read and follow .claude/skills/fix-github-issue/SKILL.md for the full workflow.
             After fixing, read and follow .claude/skills/raise-pr/SKILL.md to raise a PR.
             CI notes: use default Metro port (8081).
 


### PR DESCRIPTION
## Description

Fixes two issues found in Agent Fix run #23455139708 ($12.70, 136 turns, 60 min):

**1. Agent fixed the wrong issue** — Was assigned #1914 but fixed #2175 instead. The prompt said "Fix this GitHub issue" without specifying which one. Now passes `#${{ github.event.issue.number }}` and title explicitly, matching how agent-triage already works.

**2. Agent created PR with wrong token** — PR #2196 was created as `app/github-actions` (unmergeable) because the agent used bare `gh pr create` instead of `GH_TOKEN="$AGENT_PR_TOKEN"`. Adds pre-flight token verification, fallback to `SHOPIFY_GH_ACCESS_TOKEN`, and post-creation author check to the raise-pr skill.

## Reviewers' hat-rack :tophat:

- `agent-fix.yml`: compare the prompt with agent-triage.yml which already passes issue context correctly
- `raise-pr/SKILL.md`: check the new blockquote verification steps are clear enough to prevent the agent from skipping them

## Test plan
- [ ] Next agent-fix run targets the correct issue
- [ ] Next agent-fix run creates PRs with the correct author (not `app/github-actions`)
