### PR TITLE
chore(ci): disable Co-authored-by in agent workflows

### DIFF
--- a/.github/workflows/agent-android-bot.yml
+++ b/.github/workflows/agent-android-bot.yml
@@ -158,7 +158,7 @@ jobs:
           claude_args: >-
             --model claude-opus-4-6
             --allowedTools "${{ env.ALLOWED_TOOLS }}"
-            --append-system-prompt "You are running on CI (GitHub Actions). Environment: Ubuntu runner with Android emulator running (device Android35). No iOS simulator. Use agent-device with --platform android --session droid. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081). When done, write a brief feedback file to /tmp/agent-feedback.md covering: what you accomplished, tools you needed but couldn't use, issues with skill instructions, suggestions for improvement."
+            --append-system-prompt "You are running on CI (GitHub Actions). Environment: Ubuntu runner with Android emulator running (device Android35). No iOS simulator. Use agent-device with --platform android --session droid. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081). IMPORTANT: Do NOT add Co-authored-by lines to any commits. No AI or human co-author trailers. When done, write a brief feedback file to /tmp/agent-feedback.md covering: what you accomplished, tools you needed but couldn't use, issues with skill instructions, suggestions for improvement."
           prompt: ${{ github.event.inputs.prompt || '' }}
 
       - name: Upload agent feedback

--- a/.github/workflows/agent-bot.yml
+++ b/.github/workflows/agent-bot.yml
@@ -82,7 +82,7 @@ jobs:
           claude_args: >-
             --model claude-opus-4-6
             --allowedTools "${{ env.ALLOWED_TOOLS }}"
-            --append-system-prompt "You are running on CI (GitHub Actions). Environment: macOS runner with Xcode and iOS simulator. No Android emulator. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081). When done, write a brief feedback file to /tmp/agent-feedback.md covering: what you accomplished, tools you needed but couldn't use, issues with skill instructions, suggestions for improvement."
+            --append-system-prompt "You are running on CI (GitHub Actions). Environment: macOS runner with Xcode and iOS simulator. No Android emulator. Read and use skills from .claude/skills/ when relevant. CI notes: use default Metro port (8081). IMPORTANT: Do NOT add Co-authored-by lines to any commits. No AI or human co-author trailers. When done, write a brief feedback file to /tmp/agent-feedback.md covering: what you accomplished, tools you needed but couldn't use, issues with skill instructions, suggestions for improvement."
           prompt: ${{ github.event.inputs.prompt || '' }}
 
       - name: Upload agent feedback

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -87,6 +87,7 @@ jobs:
             Fix ONLY this issue — do not fix other issues. Read and follow .claude/skills/fix-github-issue/SKILL.md for the full workflow.
             After fixing, read and follow .claude/skills/raise-pr/SKILL.md to raise a PR.
             CI notes: use default Metro port (8081).
+            IMPORTANT: Do NOT add Co-authored-by lines to any commits. No AI or human co-author trailers.
 
             When done (whether successful or not), write a brief feedback file to /tmp/agent-feedback.md with:
             - What you accomplished (or where you got stuck)


### PR DESCRIPTION
## Description

Disable Co-authored-by trailers in all agent workflows. `claude-code-action` automatically injects `Co-authored-by` for whoever triggers the agent (via comment or label), but this is unwanted — agent commits should have no human co-author attribution.

Adds "Do NOT add Co-authored-by lines to any commits" to the system prompt of agent-fix, agent-bot, and agent-android-bot workflows. Skips agent-triage since it doesn't create commits.

## Reviewers' hat-rack :tophat:

Check that the instruction is placed prominently enough in each prompt to override claude-code-action's built-in co-author injection.

## Test plan
- [x] Next agent commit on a PR has no Co-authored-by trailer
