### PR TITLE
Add isStickyItem predicate callback for declarative sticky headers

### DIFF
--- a/fixture/react-native/src/contacts/Contacts.tsx
+++ b/fixture/react-native/src/contacts/Contacts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { FlashList } from "@shopify/flash-list";
 import { ScrollView } from "react-native";
 
@@ -23,15 +23,10 @@ const Contacts = () => {
     setData(contactsWithTitles);
   }, []);
 
-  const stickyHeaderIndices = data
-    .map((item, index) => {
-      if (typeof item === "string") {
-        return index;
-      } else {
-        return null;
-      }
-    })
-    .filter((item) => item !== null) as number[];
+  const isStickyItem = useCallback(
+    (item: Contact | string) => typeof item === "string",
+    []
+  );
 
   const renderScrollComponent = useMemo(() => {
     // eslint-disable-next-line react/display-name
@@ -55,7 +50,7 @@ const Contacts = () => {
         return typeof item === "string" ? "sectionHeader" : "row";
       }}
       ItemSeparatorComponent={ContactDivider}
-      stickyHeaderIndices={stickyHeaderIndices}
+      isStickyItem={isStickyItem}
       ListHeaderComponent={ContactHeader}
       initialScrollIndex={debugContext.initialScrollIndex}
       renderScrollComponent={renderScrollComponent}

--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -408,4 +408,12 @@ export interface FlashListProps<TItem>
         hideRelatedCell?: boolean;
       }
     | undefined;
+
+  /**
+   * Predicate function to determine which items should be sticky headers.
+   * Called for each item in `data`. Return `true` to make the item sticky.
+   * This is an alternative to `stickyHeaderIndices` — do not use both.
+   * For best performance, memoize with `useCallback`.
+   */
+  isStickyItem?: (item: TItem, index: number) => boolean;
 }

--- a/src/__tests__/useStickyHeaderIndices.test.tsx
+++ b/src/__tests__/useStickyHeaderIndices.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { Text } from "react-native";
+import "@quilted/react-testing/matchers";
+import { render } from "@quilted/react-testing";
+
+import { useStickyHeaderIndices } from "../recyclerview/hooks/useStickyHeaderIndices";
+
+/**
+ * Test wrapper that renders the hook result as text for assertion.
+ */
+function TestComponent<T>({
+  isStickyItem,
+  data,
+  stickyHeaderIndicesProp,
+}: {
+  isStickyItem?: (item: T, index: number) => boolean;
+  data: ReadonlyArray<T> | null | undefined;
+  stickyHeaderIndicesProp?: number[];
+}) {
+  const result = useStickyHeaderIndices(
+    isStickyItem,
+    data,
+    stickyHeaderIndicesProp
+  );
+  return <Text>{JSON.stringify(result ?? null)}</Text>;
+}
+
+function expectResult(rendered: ReturnType<typeof render>, expected: string) {
+  expect(rendered).toContainReactComponent(Text, { children: expected });
+}
+
+describe("useStickyHeaderIndices", () => {
+  it("should derive indices from isStickyItem predicate", () => {
+    const data = ["header", "item", "item", "header", "item"];
+    const result = render(
+      <TestComponent
+        isStickyItem={(item: string) => item === "header"}
+        data={data}
+      />
+    );
+    expectResult(result, JSON.stringify([0, 3]));
+  });
+
+  it("should return stickyHeaderIndicesProp when isStickyItem is not provided", () => {
+    const data = ["a", "b", "c"];
+    const result = render(
+      <TestComponent
+        data={data}
+        stickyHeaderIndicesProp={[0, 2]}
+      />
+    );
+    expectResult(result, JSON.stringify([0, 2]));
+  });
+
+  it("should return undefined when neither prop is provided", () => {
+    const result = render(<TestComponent data={["a", "b"]} />);
+    expectResult(result, "null");
+  });
+
+  it("should prefer isStickyItem over stickyHeaderIndicesProp", () => {
+    const data = ["header", "item", "header"];
+    const result = render(
+      <TestComponent
+        isStickyItem={(item: string) => item === "header"}
+        data={data}
+        stickyHeaderIndicesProp={[1]}
+      />
+    );
+    expectResult(result, JSON.stringify([0, 2]));
+  });
+
+  it("should return empty array when isStickyItem returns false for all items", () => {
+    const data = ["a", "b", "c"];
+    const result = render(
+      <TestComponent isStickyItem={() => false} data={data} />
+    );
+    expectResult(result, JSON.stringify([]));
+  });
+
+  it("should return empty array when data is empty and isStickyItem is provided", () => {
+    const result = render(
+      <TestComponent isStickyItem={() => true} data={[]} />
+    );
+    expectResult(result, JSON.stringify([]));
+  });
+
+  it("should return stickyHeaderIndicesProp when data is null", () => {
+    const result = render(
+      <TestComponent
+        isStickyItem={() => true}
+        data={null}
+        stickyHeaderIndicesProp={[0]}
+      />
+    );
+    expectResult(result, JSON.stringify([0]));
+  });
+
+  it("should pass index as second argument to predicate", () => {
+    const data = ["a", "b", "c", "d", "e"];
+    const result = render(
+      <TestComponent
+        isStickyItem={(_: string, index: number) => index % 2 === 0}
+        data={data}
+      />
+    );
+    expectResult(result, JSON.stringify([0, 2, 4]));
+  });
+});

--- a/src/errors/WarningMessages.ts
+++ b/src/errors/WarningMessages.ts
@@ -3,6 +3,8 @@ export const WarningMessages = {
     "keyExtractor is not defined. This might cause the animations to not work as expected.",
   keyExtractorNotDefinedForMVCP:
     "keyExtractor is not defined, maintainVisibleContentPosition may not work as expected.",
+  isStickyItemAndStickyHeaderIndicesBothProvided:
+    "Both isStickyItem and stickyHeaderIndices are provided. isStickyItem will take precedence. Remove stickyHeaderIndices to silence this warning.",
   exceededMaxRendersWithoutCommit:
     "Exceeded max renders without commit. This might mean that you have duplicate keys in your keyExtractor output or your list is nested in a ScrollView causing a lot of items to render at once. " +
     "If it's none of those and is causing a real issue or error, consider reporing this on FlashList Github",

--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -51,6 +51,7 @@ import { useSecondaryProps } from "./hooks/useSecondaryProps";
 import { StickyHeaders, StickyHeaderRef } from "./components/StickyHeaders";
 import { ScrollAnchor, ScrollAnchorRef } from "./components/ScrollAnchor";
 import { useRecyclerViewController } from "./hooks/useRecyclerViewController";
+import { useStickyHeaderIndices } from "./hooks/useStickyHeaderIndices";
 import { RenderTimeTracker } from "./helpers/RenderTimeTracker";
 
 /**
@@ -81,7 +82,8 @@ const RecyclerViewComponent = <T,>(
     ItemSeparatorComponent,
     renderScrollComponent,
     style,
-    stickyHeaderIndices,
+    stickyHeaderIndices: stickyHeaderIndicesProp,
+    isStickyItem,
     maintainVisibleContentPosition,
     onCommitLayoutEffect,
     onChangeStickyIndex,
@@ -99,6 +101,18 @@ const RecyclerViewComponent = <T,>(
     stickyHeaderConfig?.useNativeDriver ?? true;
   const stickyHeaderHideRelatedCell =
     stickyHeaderConfig?.hideRelatedCell ?? false;
+
+  if (isStickyItem && stickyHeaderIndicesProp) {
+    console.warn(
+      WarningMessages.isStickyItemAndStickyHeaderIndicesBothProvided
+    );
+  }
+
+  const stickyHeaderIndices = useStickyHeaderIndices(
+    isStickyItem,
+    data,
+    stickyHeaderIndicesProp
+  );
 
   // Core refs for managing scroll view, internal view, and child container
   const scrollViewRef = useRef<CompatScroller>(null);

--- a/src/recyclerview/hooks/useStickyHeaderIndices.ts
+++ b/src/recyclerview/hooks/useStickyHeaderIndices.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+
+/**
+ * Derives sticky header indices from either an `isStickyItem` predicate or
+ * an explicit `stickyHeaderIndices` array. When `isStickyItem` is provided,
+ * it takes precedence and the indices are recomputed whenever `data` changes.
+ */
+export function useStickyHeaderIndices<TItem>(
+  isStickyItem: ((item: TItem, index: number) => boolean) | undefined,
+  data: ReadonlyArray<TItem> | null | undefined,
+  stickyHeaderIndicesProp: number[] | undefined
+): number[] | undefined {
+  return useMemo(() => {
+    if (isStickyItem && data) {
+      const indices: number[] = [];
+      for (let i = 0; i < data.length; i++) {
+        if (isStickyItem(data[i], i)) {
+          indices.push(i);
+        }
+      }
+      return indices;
+    }
+    return stickyHeaderIndicesProp;
+  }, [isStickyItem, data, stickyHeaderIndicesProp]);
+}


### PR DESCRIPTION
Introduces an `isStickyItem` prop as an alternative to `stickyHeaderIndices`. Instead of maintaining a fragile array of indices that must be recomputed on every data change, consumers can now supply a predicate function `(item, index) => boolean` and FlashList derives the indices internally.

https://github.com/user-attachments/assets/668e4dc5-fa57-485a-abfb-57546943b2d5


- Add `isStickyItem` prop to `FlashListProps<TItem>`
- Create `useStickyHeaderIndices` hook to derive indices from the predicate
- Wire up in RecyclerView with backward-compatible fallback to `stickyHeaderIndices`
- Warn when both props are provided (isStickyItem takes precedence)
- Add 8 unit tests covering derivation, fallback, precedence, and edge cases

## Description

Fixes (issue #)

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->
