### PR TITLE
fix(layout): skip layout updates when container size is 0x0

### DIFF
--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -166,6 +166,10 @@ const RecyclerViewComponent = <T,>(
     if (internalViewRef.current && firstChildViewRef.current) {
       // Measure the outer container size and inner container layout
       const outerViewSize = measureParentSize(internalViewRef.current);
+      if (outerViewSize.width === 0 && outerViewSize.height === 0) {
+        containerViewSizeRef.current = outerViewSize;
+        return;
+      }
       const firstChildViewLayout = measureFirstChildLayout(
         firstChildViewRef.current,
         internalViewRef.current
@@ -202,6 +206,12 @@ const RecyclerViewComponent = <T,>(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     if (pendingChildIds.size > 0) {
+      return;
+    }
+    if (
+      containerViewSizeRef.current?.width === 0 &&
+      containerViewSizeRef.current?.height === 0
+    ) {
       return;
     }
     const layoutInfo = Array.from(refHolder, ([index, viewHolderRef]) => {

--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -238,8 +238,14 @@ export function useRecyclerViewController<T>(
       }: ScrollToOffsetParams) => {
         const { horizontal } = recyclerViewManager.props;
         if (scrollViewRef.current) {
-          // Adjust offset for RTL layouts in horizontal mode
-          if (I18nManager.isRTL && horizontal) {
+          // Adjust offset for RTL layouts in horizontal mode.
+          // Gated on hasLayout(): the RTL math reads child container and
+          // window size, which throw while the list is hidden (0x0).
+          if (
+            I18nManager.isRTL &&
+            horizontal &&
+            recyclerViewManager.hasLayout()
+          ) {
             // eslint-disable-next-line no-param-reassign
             offset =
               adjustOffsetForRTL(
@@ -323,6 +329,12 @@ export function useRecyclerViewController<T>(
         viewPosition,
         viewOffset,
       }: ScrollToIndexParams): Promise<void> => {
+        // While the list is hidden (parent measured 0x0) the layout manager
+        // is never initialized, so reading window size below would throw.
+        // No-op until the next layout pass makes scrolling meaningful.
+        if (!recyclerViewManager.hasLayout()) {
+          return Promise.resolve();
+        }
         return new Promise((resolve) => {
           const { horizontal } = recyclerViewManager.props;
           if (


### PR DESCRIPTION
## Description

Fixes #2231

When FlashList is mounted inside a screen rendered by `@react-navigation/stack` on web, pushing a new screen on top of it transiently measures FlashList's container as `0x0`. The two layout `useLayoutEffect`s in `RecyclerView` then run with those bogus dimensions: the first overwrites the window/layout params with zeros, and the second walks every `viewHolderRef` and rewrites item layouts. The downstream effect is that every `renderItem` re-runs — including offscreen items — which defeats recycling and causes the perf regression in the linked Snack repro.

This PR adds two early returns inside `src/recyclerview/RecyclerView.tsx`:

1. In the post-mount layout effect: if the outer container measures `0x0`, store that size in `containerViewSizeRef` and bail out before calling `recyclerViewManager.updateLayoutParams(...)`.
2. In the per-item layout effect: if `containerViewSizeRef.current` is `0x0`, bail out before iterating `refHolder` and rewriting layouts.

Once the screen is brought back into view and the container regains a non-zero size, the normal layout path resumes on the next layout pass — no items are dropped or re-mounted.

This is the same patch Expensify currently ships against `@shopify/flash-list@2.3.0` for the same root cause discussed in #1816, and it removes the need for consumers to remember to toggle a Navigator-level workaround at every call site.

## Reviewers' hat-rack :tophat:

- [ ] Confirm the first early return still writes `containerViewSizeRef.current = outerViewSize` before bailing, so the second effect can detect the `0x0` state.
- [ ] Reproduce #2231 against `main` using the Snack from the issue, then re-run against this branch and verify offscreen items stop re-rendering when a stack screen is pushed on top.
- [ ] Verify there's no regression on lists that legitimately mount with non-zero size on the first measurement (mobile + web), i.e. the fast path is unchanged.
- [ ] Sanity-check that layout converges on the next non-zero measurement after the container is restored — items shouldn't be left half-measured.

## Screenshots or videos 

After-fix recording: 

https://github.com/user-attachments/assets/124b5032-c3ea-423c-8fbc-037097747295

