### PR TITLE
fix(layout): invalidate cached row heights on in-place data swap

### DIFF
--- a/src/__tests__/RecyclerViewManager.test.ts
+++ b/src/__tests__/RecyclerViewManager.test.ts
@@ -71,4 +71,166 @@ describe("RecyclerViewManager", () => {
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("processDataUpdate — layout invalidation on in-place data swap", () => {
+    interface Item {
+      id: number;
+    }
+    const keyExtractor = (item: Item) => `item-${item.id}`;
+
+    const createGridManager = (data: Item[], overrides = {}) => {
+      const props = {
+        data,
+        renderItem: jest.fn(),
+        keyExtractor,
+        numColumns: 2,
+        ...overrides,
+      } as FlashListProps<Item>;
+      const manager = new RecyclerViewManager<Item>(props);
+      manager.processDataUpdate();
+      manager.updateLayoutParams({ width: 400, height: 900 }, 0);
+      manager.processDataUpdate();
+      return manager;
+    };
+
+    const markAsMeasured = (
+      manager: RecyclerViewManager<Item>,
+      indices: number[],
+      height: number
+    ) => {
+      for (const i of indices) {
+        const layout = manager.getLayout(i);
+        layout.isHeightMeasured = true;
+        layout.minHeight = height;
+        layout.height = height;
+      }
+    };
+
+    it("invalidates cached height for indices whose key changed", () => {
+      const initialData: Item[] = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const manager = createGridManager(initialData);
+      markAsMeasured(manager, [0, 1, 2, 3], 200);
+
+      // Replace items at index 0 and 2 (different identities)
+      const swappedData: Item[] = [
+        { id: 100 },
+        initialData[1],
+        { id: 300 },
+        initialData[3],
+      ];
+      manager.updateProps({
+        ...manager.props,
+        data: swappedData,
+      });
+      manager.processDataUpdate();
+
+      expect(manager.getLayout(0).isHeightMeasured).toBe(false);
+      expect(manager.getLayout(0).minHeight).toBeUndefined();
+      expect(manager.getLayout(2).isHeightMeasured).toBe(false);
+      expect(manager.getLayout(2).minHeight).toBeUndefined();
+
+      // Unchanged identities keep their cached measurement
+      expect(manager.getLayout(1).isHeightMeasured).toBe(true);
+      expect(manager.getLayout(1).minHeight).toBe(200);
+      expect(manager.getLayout(3).isHeightMeasured).toBe(true);
+      expect(manager.getLayout(3).minHeight).toBe(200);
+    });
+
+    it("invalidates every index when the whole array is replaced", () => {
+      const initialData: Item[] = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const manager = createGridManager(initialData);
+      markAsMeasured(manager, [0, 1, 2, 3], 200);
+
+      // Category switch — entirely different items at every position
+      const swappedData: Item[] = [
+        { id: 10 },
+        { id: 20 },
+        { id: 30 },
+        { id: 40 },
+      ];
+      manager.updateProps({
+        ...manager.props,
+        data: swappedData,
+      });
+      manager.processDataUpdate();
+
+      for (let i = 0; i < swappedData.length; i++) {
+        expect(manager.getLayout(i).isHeightMeasured).toBe(false);
+        expect(manager.getLayout(i).minHeight).toBeUndefined();
+      }
+    });
+
+    it("does not invalidate when the same items are re-emitted at the same positions", () => {
+      const initialData: Item[] = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const manager = createGridManager(initialData);
+      markAsMeasured(manager, [0, 1, 2, 3], 200);
+
+      // New array reference, same identities — e.g. a query refetch returning equal data
+      const sameData: Item[] = initialData.map((item) => ({ id: item.id }));
+      manager.updateProps({
+        ...manager.props,
+        data: sameData,
+      });
+      manager.processDataUpdate();
+
+      for (let i = 0; i < sameData.length; i++) {
+        expect(manager.getLayout(i).isHeightMeasured).toBe(true);
+        expect(manager.getLayout(i).minHeight).toBe(200);
+      }
+    });
+
+    it("does not invalidate measured heights for indices that survived an append", () => {
+      const initialData: Item[] = [{ id: 1 }, { id: 2 }];
+      const manager = createGridManager(initialData);
+      markAsMeasured(manager, [0, 1], 200);
+
+      const appendedData: Item[] = [...initialData, { id: 3 }, { id: 4 }];
+      manager.updateProps({
+        ...manager.props,
+        data: appendedData,
+      });
+      manager.processDataUpdate();
+
+      // Pre-existing indices: keys unchanged, so invalidation must not reset
+      // `isHeightMeasured` or `height` (the per-row normalization that runs
+      // when new indices are appended is a separate concern).
+      expect(manager.getLayout(0).isHeightMeasured).toBe(true);
+      expect(manager.getLayout(0).height).toBe(200);
+      expect(manager.getLayout(1).isHeightMeasured).toBe(true);
+      expect(manager.getLayout(1).height).toBe(200);
+    });
+
+    it("is a no-op when keyExtractor is not provided", () => {
+      const initialData: Item[] = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const props = {
+        data: initialData,
+        renderItem: jest.fn(),
+        numColumns: 2,
+      } as FlashListProps<Item>;
+      const manager = new RecyclerViewManager<Item>(props);
+      manager.processDataUpdate();
+      manager.updateLayoutParams({ width: 400, height: 900 }, 0);
+      manager.processDataUpdate();
+      markAsMeasured(manager, [0, 1, 2, 3], 200);
+
+      const swappedData: Item[] = [
+        { id: 10 },
+        { id: 20 },
+        { id: 30 },
+        { id: 40 },
+      ];
+      manager.updateProps({
+        ...manager.props,
+        data: swappedData,
+      });
+      manager.processDataUpdate();
+
+      // Without stable keys we cannot tell positions apart safely, so we leave
+      // the cached measurements alone (matching the pre-fix behavior).
+      for (let i = 0; i < swappedData.length; i++) {
+        expect(manager.getLayout(i).isHeightMeasured).toBe(true);
+        expect(manager.getLayout(i).minHeight).toBe(200);
+      }
+    });
+  });
 });

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -35,6 +35,15 @@ export class RecyclerViewManager<T> {
   private _isDisposed = false;
   private _isLayoutManagerDirty = false;
   private _animationOptimizationsEnabled = false;
+  /**
+   * Snapshot of `keyExtractor(item, index)` results from the last
+   * processDataUpdate call, indexed by position. Used to detect when the
+   * item at a given index has been replaced by a different one on an
+   * in-place data swap so we can invalidate that index's stale measured
+   * height/minHeight and let it be remeasured against the new content.
+   * See `invalidateChangedLayouts`.
+   */
+  private prevDataKeys: string[] = [];
 
   public firstItemOffset = 0;
   public ignoreScrollEvents = false;
@@ -301,12 +310,68 @@ export class RecyclerViewManager<T> {
 
   processDataUpdate() {
     if (this.hasLayout()) {
+      this.invalidateChangedLayouts();
       this.modifyChildrenLayout([], this.propsRef.data?.length ?? 0);
       if (this.hasRenderedProgressively && !this.recomputeEngagedIndices()) {
         // recomputeEngagedIndices will update the render stack if there are any changes in the engaged indices.
         // It's important to update render stack so that elements are assgined right keys incase items were deleted.
         this.updateRenderStack(this.engagedIndicesTracker.getEngagedIndices());
       }
+    } else {
+      this.recordCurrentDataKeys();
+    }
+  }
+
+  /**
+   * Detects per-index identity changes between the previous and current data
+   * arrays (using keyExtractor) and invalidates the cached measured height
+   * for indices whose item changed.
+   *
+   * Without this, an in-place data swap (e.g. category/filter change) leaves
+   * the LayoutManager believing every index is still measured at its previous
+   * height. In a multi-column grid this leaks the previous row's tallest-item
+   * constraint onto the new content: the ViewHolder applies the stale
+   * `minHeight`, and the row's `y` for the next row is computed against the
+   * stale height — so a taller new card overflows into the row below.
+   *
+   * Clearing `isHeightMeasured` ensures the next `modifyLayout` call sees
+   * the index as needing a fresh recompute via
+   * `computeEstimatesAndMinMaxChangedLayout`, and clearing `minHeight` stops
+   * the stale constraint from being applied in the next render before the
+   * first measurement arrives.
+   *
+   * No-op when `keyExtractor` is not provided (we cannot safely diff
+   * positions without stable keys).
+   */
+  private invalidateChangedLayouts(): void {
+    if (!this.hasStableDataKeys() || !this.layoutManager) {
+      this.recordCurrentDataKeys();
+      return;
+    }
+    const newLength = this.getDataLength();
+    const layoutCount = this.layoutManager.getLayoutCount();
+    const compareLength = Math.min(layoutCount, newLength);
+    for (let i = 0; i < compareLength; i++) {
+      const oldKey = this.prevDataKeys[i];
+      const newKey = this.getDataKey(i);
+      if (oldKey !== undefined && oldKey !== newKey) {
+        const layout = this.layoutManager.getLayout(i);
+        layout.isHeightMeasured = false;
+        layout.minHeight = undefined;
+      }
+    }
+    this.recordCurrentDataKeys();
+  }
+
+  private recordCurrentDataKeys(): void {
+    if (!this.hasStableDataKeys()) {
+      this.prevDataKeys.length = 0;
+      return;
+    }
+    const newLength = this.getDataLength();
+    this.prevDataKeys.length = newLength;
+    for (let i = 0; i < newLength; i++) {
+      this.prevDataKeys[i] = this.getDataKey(i);
     }
   }
 


### PR DESCRIPTION
## Description

When the `data` prop of a `FlashList` is replaced in place — that is, the list itself is not unmounted but the underlying array is swapped for a different one (e.g. on category / filter / sort change) — items in a multi-column grid can overlap with the row below them.

The screenshot below is a real reproduction in a production app on `@shopify/flash-list@2.3.1` with `numColumns={2}`. After switching the category, the new product cards in row N are taller than the cards that were previously at those positions, and they overlap into row N+1:

<img width="422" height="776" alt="image" src="https://github.com/user-attachments/assets/4f7bd1f0-a176-478c-9275-8536884a0ed8" />


### Root cause

`RecyclerViewManager.processDataUpdate` is called from `useRecyclerViewManager`'s `useMemo([data])`. Its current implementation forwards an empty `layoutInfo` array to `modifyChildrenLayout`, so on an in-place data swap the `LayoutManager` is told that the data length changed but nothing else:

```ts
processDataUpdate() {
  if (this.hasLayout()) {
    this.modifyChildrenLayout([], this.propsRef.data?.length ?? 0);
    // ...
  }
}
```

The per-index entries in `LayoutManager.layouts` therefore keep their previous values:

- `isHeightMeasured: true` (set after the previous render's `onLayout`)
- `height` (the previously measured pixel height)
- `minHeight` (the row's normalized height set by `processAndReturnTallestItemInRow`)

On the next render the new item at that index is mounted by the `ViewHolder` with the stale `minHeight` applied as a style. Two things go wrong:

1. **Content-driven overflow.** `ViewHolder` does not enforce `height` for non-grid items, so the new content stretches the cell past its cached `height`. The row above looks taller than the layout says it is.
2. **Stale row positioning.** `recomputeLayouts` places the next row's `y` from the cached `height` of the current row before any fresh measurement arrives. The next row therefore starts too high, and the overflowing cell of the previous row visually overlaps it.

There is also a second-order effect inside `GridLayoutManager.processAndReturnTallestItemInRow`: a row's "tallest item" is only nominated if `layout.height > layout.minHeight`. After the previous render's normalization, the previously tallest item has `minHeight = 0` while its neighbours have `minHeight === height`. When the new data is taller at a previously short position, the comparison `height > minHeight` fails for the previously normalized neighbour, so it cannot be picked as the tallest. The row's normalized height ends up driven by the wrong item, and one further frame is required before the layout converges — sometimes only after the user scrolls the affected rows back into view.

The library already has `clearLayoutCacheOnUpdate()` for the heavy case (e.g. orientation change), but that wipes the entire cache and the docs say it should be called manually before render, which doesn't fit in-place data updates.

### The fix

Track each render's `keyExtractor` results per index. When `processDataUpdate` runs and the layout manager already exists, diff the new keys against the previously recorded ones; for any index whose key changed, clear `isHeightMeasured` and `minHeight` on its layout. The next time `modifyLayout` receives real measurements from the freshly rendered `ViewHolder`s, `computeEstimatesAndMinMaxChangedLayout` sees `!isHeightMeasured` and triggers a fresh recompute of those rows. No row is positioned against a stale height for the new content.

The patch is entirely additive on a private code path and is a no-op when `keyExtractor` is not provided, so it cannot regress existing callers.

### What's covered

| scenario | behavior |
| --- | --- |
| index identity changed (partial swap) | invalidated |
| whole array replaced (e.g. category switch) | every index invalidated |
| identical keys re-emitted (e.g. refetch returning the same payload) | no-op |
| append at the tail (pagination) | pre-existing indices untouched |
| no `keyExtractor` provided | no-op, pre-fix behavior preserved |
| masonry / linear layouts | no-op for row normalization but still clears stale `minHeight` |

## Reviewers' hat-rack :tophat:

- [ ] `RecyclerViewManager.invalidateChangedLayouts` only mutates layouts whose index is in `[0, min(layoutCount, newLength))`. Indices that exist only in the previous data (i.e., the array shrunk) are trimmed inside `modifyLayout` as before. Indices that exist only in the new data are created by `modifyLayout` after this call and are not touched.
- [ ] `recordCurrentDataKeys` is called from both branches of `processDataUpdate` and from the early-return inside `invalidateChangedLayouts`, so `prevDataKeys` stays in sync with the most recently rendered data even when the layout manager isn't ready yet (first paint).
- [ ] When `keyExtractor` is undefined, `prevDataKeys` is explicitly truncated to zero length so a later flip to providing a `keyExtractor` doesn't reuse stale keys from an earlier session.

## Tests

`src/__tests__/RecyclerViewManager.test.ts` adds five new cases under `processDataUpdate — layout invalidation on in-place data swap`. Full suite (`yarn jest`) — 188/188 passing locally. `yarn lint` and `yarn type-check` clean.

## Screenshots or videos

Repro is a 2-column product list with cards of varying height. Switching categories swaps the underlying `data` in place. Before the fix, the first frame after the swap shows cards from the new category overlapping the row below; after the fix, the next row is positioned against the fresh measurement and there is no overlap.