### PR TITLE
fix: scroll to index autoscroll race

### DIFF
--- a/fixture/react-native/src/ChatUnstableItems.tsx
+++ b/fixture/react-native/src/ChatUnstableItems.tsx
@@ -1,0 +1,412 @@
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+  useEffect,
+} from "react";
+import {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  Pressable,
+  SafeAreaView,
+  StatusBar,
+} from "react-native";
+import {
+  FlashList,
+  FlashListRef,
+  useRecyclingState,
+} from "@shopify/flash-list";
+
+interface ChatMessage {
+  id: string;
+  text: string;
+  sender: "user" | "other";
+  timestamp: Date;
+}
+
+const messageTexts = [
+  "Hey, how are you?",
+  "Hey, how are you? Hey, how are you? Hey, how are you? Hey, how are you?",
+  "What's up?",
+  "What's up? What's up? What's up?",
+  "Did you see that new movie?",
+  "I'm working on a new project",
+  "Let's catch up soon!",
+  "Have you tried the new restaurant downtown?",
+  "Have you tried the new restaurant downtown?, Have you tried the new restaurant downtown?, Have you tried the new restaurant downtown?, Have you tried the new restaurant downtown?",
+  "Just finished reading an amazing book",
+  "Can you send me that file?",
+  "Are we still meeting tomorrow?",
+  [
+    "Are we still meeting tomorrow?",
+    "Are we still meeting tomorrow?",
+    "Are we still meeting tomorrow?",
+    "Are we still meeting tomorrow?",
+    "Are we still meeting tomorrow?",
+    "Are we still meeting tomorrow?",
+    "Are we still meeting tomorrow?",
+  ].join(" "),
+  "The weather is beautiful today!",
+  "The weather is beautiful today! The weather is beautiful today!",
+];
+
+export function ChatUnstableItems() {
+  const [messages, setMessages] = useState<ChatMessage[]>(() =>
+    generateInitialMessages(300)
+  );
+  const listRef = useRef<FlashListRef<ChatMessage>>(null);
+
+  const addMessageAtTop = useCallback(() => {
+    const newMessages = Array.from({ length: 50 }, (_, i) =>
+      generateRandomMessage(i)
+    );
+    setMessages((prev) => [...newMessages, ...prev]);
+  }, []);
+
+  // const addMessageAtBottom = useCallback(() => {
+  //   const newMessage = generateRandomMessage(messages.length);
+  //   setMessages((prev) => [...prev, newMessage]);
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
+
+  // Mirror stream-chat-react-native's "tap a reply" timing pattern:
+  // the tap schedules a state update; the actual scrollToIndex runs on a
+  // later tick via setTimeout(0). This separates the re-render (where
+  // applyOffsetCorrection can fire its stray scrollBy with the anchor's
+  // stale layout snapshot) from the scrollToIndex call (which would
+  // otherwise have already set pauseOffsetCorrection.current = true and
+  // suppressed the stray scrollBy).
+  const [scrollTarget, setScrollTarget] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (scrollTarget === null) return undefined;
+    const id = setTimeout(() => {
+      listRef.current?.scrollToIndex({
+        index: scrollTarget,
+        animated: true,
+        viewPosition: 0.5,
+      });
+      setScrollTarget(null);
+    }, 0);
+    return () => clearTimeout(id);
+  }, [scrollTarget]);
+
+  const scrollToItem25 = useCallback(() => {
+    setScrollTarget(150);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    listRef.current?.scrollToEnd({ animated: true });
+  }, []);
+
+  const renderItem = useCallback((info: { item: ChatMessage }) => {
+    return <MessageBubble message={info.item} />;
+  }, []);
+
+  const maintainVisibleContentPositionConfig = useMemo(
+    () => ({
+      animateAutoScrollToBottom: true,
+      autoscrollToBottomThreshold: 1,
+      startRenderingFromBottom: true,
+    }),
+    []
+  );
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Chat Example</Text>
+      </View>
+    ),
+    []
+  );
+
+  const keyExtractor = useCallback((item: ChatMessage) => item.id, []);
+
+  return (
+    <SafeAreaView style={styles.safeArea} testID="ChatUnstableItemsScreen">
+      <StatusBar barStyle="dark-content" />
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>Chat Example</Text>
+        </View>
+
+        <View style={styles.buttonContainer}>
+          <Pressable
+            style={[styles.button, styles.topButton]}
+            onPress={addMessageAtTop}
+          >
+            <Text style={styles.buttonText}>Add at Top</Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.button, styles.scrollBottomButton]}
+            onPress={scrollToBottom}
+          >
+            <Text style={styles.buttonText}>Scroll to Bottom</Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.button, styles.scrollButton]}
+            onPress={scrollToItem25}
+          >
+            <Text style={styles.buttonText}>Scroll to 25</Text>
+          </Pressable>
+        </View>
+
+        <FlashList
+          ref={listRef}
+          data={messages}
+          maintainVisibleContentPosition={maintainVisibleContentPositionConfig}
+          // onStartReached={() => {
+          //   console.log("onStartReached");
+          //   addMessageAtTop();
+          // }}
+          ListHeaderComponent={listHeaderComponent}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function generateInitialMessages(count: number): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  const now = new Date();
+
+  for (let i = 0; i < count; i++) {
+    const minutesAgo = count - i;
+    const timestamp = new Date(now.getTime() - minutesAgo * 60000);
+
+    messages.push({
+      id: `msg-${i}`,
+      text: `${i}. ${messageTexts[i % messageTexts.length]}`,
+      sender: i % 2 === 0 ? "user" : "other",
+      timestamp,
+    });
+  }
+
+  return messages;
+}
+
+function generateRandomMessage(index: number): ChatMessage {
+  return {
+    id: `msg-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
+    text: `${index}. ${messageTexts[index % messageTexts.length]}`,
+    sender: index % 2 === 0 ? "user" : "other",
+    timestamp: new Date(),
+  };
+}
+
+// deterministic hash, to be used as seed for the randomizer
+function hashString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 31 + input.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+// deterministic random based on a seed - we probably want this
+// in order to not mess measurements on every scroll (again emulating
+// actual message state which settles after some time)
+function mulberry32(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface MessageProfile {
+  paddingVertical: number;
+  paddingHorizontal: number;
+  textRepeat: number;
+  hasImage: boolean;
+  imageWidth: number;
+  imageRenderedHeight: number;
+  imagePlaceholderHeight: number;
+  imageSeed: number;
+}
+
+function computeProfile(messageId: string): MessageProfile {
+  const rand = mulberry32(hashString(messageId));
+  const hasImage = rand() < 0.35;
+  // The image is requested at imageRenderedHeight px tall, but we render
+  // the <Image> at imagePlaceholderHeight until onLoad fires, at which
+  // point we swap to the full height. That swap tries to emulate a real
+  // measurement drift: between the moment the user settles at the bottom
+  // (anchor snapshot taken) and the moment they tap, inflight image loads
+  // keep growing nearby bubbles, drifting firstVisibleItemLayout.current
+  // relative to live layout.
+  const imageRenderedHeight = 90 + Math.floor(rand() * 130);
+  return {
+    paddingVertical: 8 + Math.floor(rand() * 16),
+    paddingHorizontal: 10 + Math.floor(rand() * 8),
+    textRepeat: 1 + Math.floor(rand() * 3),
+    hasImage,
+    imageWidth: 180 + Math.floor(rand() * 60),
+    imageRenderedHeight,
+    imagePlaceholderHeight: Math.max(40, imageRenderedHeight - 60),
+    imageSeed: hashString(messageId),
+  };
+}
+
+const MessageImage = ({
+  uri,
+  width,
+  placeholderHeight,
+  finalHeight,
+}: {
+  uri: string;
+  width: number;
+  placeholderHeight: number;
+  finalHeight: number;
+}) => {
+  // useRecyclingState resets to `false` whenever `uri` changes — i.e. when
+  // FlashList recycles this cell to a different message. That guarantees
+  // every cell-image swap goes through the placeholder → finalHeight
+  // transition and produces a real onLoad-driven layout shift, which is
+  // the production-style drift mechanism we're using to make
+  // firstVisibleItemLayout.current go stale.
+  const [loaded, setLoaded] = useRecyclingState(false, [uri]);
+  return (
+    <Image
+      source={{ uri }}
+      resizeMode="cover"
+      onLoad={() => setLoaded(true)}
+      style={{
+        width,
+        height: loaded ? finalHeight : placeholderHeight,
+        borderRadius: 10,
+        marginBottom: 6,
+        backgroundColor: "#dddddd",
+      }}
+    />
+  );
+};
+
+const MessageBubble = ({ message }: { message: ChatMessage }) => {
+  const isUser = message.sender === "user";
+  const profile = useMemo(() => computeProfile(message.id), [message.id]);
+  const text = useMemo(() => {
+    if (profile.textRepeat === 1) return message.text;
+    return Array(profile.textRepeat).fill(message.text).join(" ");
+  }, [message.text, profile.textRepeat]);
+
+  return (
+    <View
+      style={[
+        styles.messageBubbleContainer,
+        isUser ? styles.userMessageContainer : styles.otherMessageContainer,
+      ]}
+    >
+      <View
+        style={[
+          styles.messageBubble,
+          isUser ? styles.userMessage : styles.otherMessage,
+          {
+            paddingVertical: profile.paddingVertical,
+            paddingHorizontal: profile.paddingHorizontal,
+          },
+        ]}
+      >
+        {profile.hasImage && (
+          <MessageImage
+            uri={`https://picsum.photos/seed/${profile.imageSeed}/${profile.imageWidth}/${profile.imageRenderedHeight}`}
+            width={profile.imageWidth}
+            placeholderHeight={profile.imagePlaceholderHeight}
+            finalHeight={profile.imageRenderedHeight}
+          />
+        )}
+        <Text style={styles.messageText}>{text}</Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#f5f5f5",
+  },
+  container: {
+    flex: 1,
+  },
+  header: {
+    padding: 16,
+    backgroundColor: "#ffffff",
+    borderBottomWidth: 1,
+    borderBottomColor: "#e0e0e0",
+    alignItems: "center",
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  buttonContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    padding: 8,
+    backgroundColor: "#ffffff",
+    borderBottomWidth: 1,
+    borderBottomColor: "#e0e0e0",
+  },
+  button: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: "45%",
+    flexGrow: 1,
+    margin: 4,
+  },
+  topButton: {
+    backgroundColor: "#4a90e2",
+  },
+  scrollButton: {
+    backgroundColor: "#e2a04a",
+  },
+  scrollBottomButton: {
+    backgroundColor: "#9c4ae2",
+  },
+  buttonText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  messageBubbleContainer: {
+    paddingHorizontal: 12,
+    marginVertical: 4,
+    flexDirection: "row",
+  },
+  userMessageContainer: {
+    justifyContent: "flex-end",
+  },
+  otherMessageContainer: {
+    justifyContent: "flex-start",
+  },
+  messageBubble: {
+    maxWidth: "80%",
+    padding: 12,
+    borderRadius: 16,
+  },
+  userMessage: {
+    backgroundColor: "#dcf8c6",
+    borderBottomRightRadius: 1,
+  },
+  otherMessage: {
+    backgroundColor: "#ffffff",
+    borderBottomLeftRadius: 1,
+  },
+  messageText: {
+    fontSize: 16,
+    color: "#000000",
+  },
+});

--- a/fixture/react-native/src/ChatUnstableItems.tsx
+++ b/fixture/react-native/src/ChatUnstableItems.tsx
@@ -54,27 +54,14 @@ const messageTexts = [
 ];
 
 export function ChatUnstableItems() {
-  const [messages, setMessages] = useState<ChatMessage[]>(() =>
+  const [messages] = useState<ChatMessage[]>(() =>
     generateInitialMessages(300)
   );
   const listRef = useRef<FlashListRef<ChatMessage>>(null);
 
-  const addMessageAtTop = useCallback(() => {
-    const newMessages = Array.from({ length: 50 }, (_, i) =>
-      generateRandomMessage(i)
-    );
-    setMessages((prev) => [...newMessages, ...prev]);
-  }, []);
-
-  // const addMessageAtBottom = useCallback(() => {
-  //   const newMessage = generateRandomMessage(messages.length);
-  //   setMessages((prev) => [...prev, newMessage]);
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
-
-  // Mirror stream-chat-react-native's "tap a reply" timing pattern:
-  // the tap schedules a state update; the actual scrollToIndex runs on a
-  // later tick via setTimeout(0). This separates the re-render (where
+  // Mirror something similar to tapping a quoted message to scroll to it.
+  // The tap schedules a state update; the actual scrollToIndex runs on a
+  // later tick via setTimeout(0). This separates the rerender (where
   // applyOffsetCorrection can fire its stray scrollBy with the anchor's
   // stale layout snapshot) from the scrollToIndex call (which would
   // otherwise have already set pauseOffsetCorrection.current = true and
@@ -136,13 +123,6 @@ export function ChatUnstableItems() {
 
         <View style={styles.buttonContainer}>
           <Pressable
-            style={[styles.button, styles.topButton]}
-            onPress={addMessageAtTop}
-          >
-            <Text style={styles.buttonText}>Add at Top</Text>
-          </Pressable>
-
-          <Pressable
             style={[styles.button, styles.scrollBottomButton]}
             onPress={scrollToBottom}
           >
@@ -161,10 +141,6 @@ export function ChatUnstableItems() {
           ref={listRef}
           data={messages}
           maintainVisibleContentPosition={maintainVisibleContentPositionConfig}
-          // onStartReached={() => {
-          //   console.log("onStartReached");
-          //   addMessageAtTop();
-          // }}
           ListHeaderComponent={listHeaderComponent}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
@@ -191,15 +167,6 @@ function generateInitialMessages(count: number): ChatMessage[] {
   }
 
   return messages;
-}
-
-function generateRandomMessage(index: number): ChatMessage {
-  return {
-    id: `msg-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
-    text: `${index}. ${messageTexts[index % messageTexts.length]}`,
-    sender: index % 2 === 0 ? "user" : "other",
-    timestamp: new Date(),
-  };
 }
 
 // deterministic hash, to be used as seed for the randomizer
@@ -269,12 +236,6 @@ const MessageImage = ({
   placeholderHeight: number;
   finalHeight: number;
 }) => {
-  // useRecyclingState resets to `false` whenever `uri` changes — i.e. when
-  // FlashList recycles this cell to a different message. That guarantees
-  // every cell-image swap goes through the placeholder → finalHeight
-  // transition and produces a real onLoad-driven layout shift, which is
-  // the production-style drift mechanism we're using to make
-  // firstVisibleItemLayout.current go stale.
   const [loaded, setLoaded] = useRecyclingState(false, [uri]);
   return (
     <Image
@@ -367,9 +328,6 @@ const styles = StyleSheet.create({
     minWidth: "45%",
     flexGrow: 1,
     margin: 4,
-  },
-  topButton: {
-    backgroundColor: "#4a90e2",
   },
   scrollButton: {
     backgroundColor: "#e2a04a",

--- a/fixture/react-native/src/ExamplesScreen.tsx
+++ b/fixture/react-native/src/ExamplesScreen.tsx
@@ -42,6 +42,10 @@ export const ExamplesScreen = () => {
       destination: "ChatInverted",
     },
     {
+      title: "Chat (Unstable Items)",
+      destination: "ChatUnstableItems",
+    },
+    {
       title: "Inverted Test",
       destination: "InvertedTest",
     },

--- a/fixture/react-native/src/NavigationTree.tsx
+++ b/fixture/react-native/src/NavigationTree.tsx
@@ -21,6 +21,7 @@ import { DynamicColumnSpan } from "./DynamicColumnSpan";
 import HorizontalList from "./HorizontalList";
 import { Chat } from "./Chat";
 import { ChatInverted } from "./ChatInverted";
+import { ChatUnstableItems } from "./ChatUnstableItems";
 import { InvertedTest } from "./InvertedTest";
 import FlashListCellRenderer from "./CellRendererExamples";
 import { HeaderFooterExample } from "./HeaderFooterExample";
@@ -80,6 +81,11 @@ const NavigationTree = () => {
             name="ChatInverted"
             component={ChatInverted}
             options={{ title: "Chat (Inverted)" }}
+          />
+          <Stack.Screen
+            name="ChatUnstableItems"
+            component={ChatUnstableItems}
+            options={{ title: "Chat (Unstable Items)" }}
           />
           <Stack.Screen
             name="InvertedTest"

--- a/fixture/react-native/src/constants.ts
+++ b/fixture/react-native/src/constants.ts
@@ -25,6 +25,7 @@ export type RootStackParamList = {
   HorizontalList: undefined;
   Chat: undefined;
   ChatInverted: undefined;
+  ChatUnstableItems: undefined;
   InvertedTest: undefined;
   CellRendererExamples: undefined;
   HeaderFooterExample: undefined;

--- a/src/__tests__/RecyclerView.test.tsx
+++ b/src/__tests__/RecyclerView.test.tsx
@@ -375,4 +375,121 @@ describe("RecyclerView", () => {
       expect(onChangeStickyIndex).toHaveBeenLastCalledWith(0, -1);
     });
   });
+
+  describe("autoscrolling to bottom is suppressed while offset projection is disabled", () => {
+    const scrollTo = (root: ReturnType<typeof render>, y: number) => {
+      const scrollable = root.findWhere((node: any) => node.props.onScroll);
+      if (!scrollable) throw new Error("Could not find scrollable component");
+
+      const onScroll: any = scrollable.prop("onScroll" as never);
+      root.act(() => {
+        onScroll({
+          nativeEvent: {
+            contentOffset: { x: 0, y },
+            contentSize: { width: 399, height: 2000 },
+            layoutMeasurement: { width: 399, height: 899 },
+          },
+        });
+      });
+    };
+
+    const renderChatList = (data: number[]) => {
+      const ref = createRef<FlashListRef<number>>();
+      const result = render(
+        <FlashList
+          ref={ref}
+          data={data}
+          renderItem={({ item }) => <Text>{item}</Text>}
+          maintainVisibleContentPosition={{
+            autoscrollToBottomThreshold: 1,
+            animateAutoScrollToBottom: false,
+            startRenderingFromBottom: true,
+          }}
+        />
+      );
+      return { result, ref };
+    };
+
+    const { measureItemLayout } = jest.requireMock(
+      "../recyclerview/utils/measureLayout"
+    ) as { measureItemLayout: jest.Mock };
+
+    it("does not fire scrollToEnd from the autoscroll path while scrollToIndex is in flight", () => {
+      const data = Array.from({ length: 20 }, (_, i) => i);
+      const { result, ref } = renderChatList(data);
+
+      const scrollToEndSpy = jest.fn();
+      const nativeScrollRef = ref.current?.getNativeScrollRef() as any;
+      expect(nativeScrollRef).toBeTruthy();
+      nativeScrollRef.scrollToEnd = scrollToEndSpy;
+
+      // 1. Load the target message into memory: scroll up so index 5
+      //    renders and is laid out at least once. After this, FlashList
+      //    has measurements for the target.
+      scrollTo(result, 200);
+      jest.runAllTimers();
+
+      // 2. Return to the bottom to arm MVCP autoscroll. The momentum-end
+      //    path in onScrollHandler refreshes firstVisibleItemKey /
+      //    firstVisibleItemLayout to a snapshot of the current anchor.
+      scrollTo(result, 1101);
+      jest.runAllTimers();
+
+      // 3. Sit still past useBoundDetection's 100ms checkBounds guard.
+      jest.advanceTimersByTime(150);
+      scrollToEndSpy.mockClear();
+
+      // 4. Simulate the background remeasurement that drifts the cached
+      //    anchor layout in an app. We change the mock so the next
+      //    measurement pass produces different item heights than the ones
+      //    cached in firstVisibleItemLayout.current. In production this
+      //    drift is a bunch  of estimates resolving into measurements
+      //    while the user sits still; in jest, we make it coarse so the
+      //    cascade is observable.
+      measureItemLayout.mockImplementation(() => ({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+      }));
+
+      // 5. Programmatic scrollToIndex on the already rendered target.
+      //    Internally: setOffsetProjectionEnabled(false), then drives the
+      //    scroll via setRenderId++. The upcoming rerender runs the
+      //    layout measurement useLayoutEffect, which absorbs the new
+      //    (drifted) heights via modifyChildrenLayout. contentHeight
+      //    therefore shifts between renders, which is exactly the
+      //    misalignment that fires useBoundDetection's second useEffect
+      //    in an actual app.
+      result.act(() => {
+        ref.current?.scrollToIndex({
+          index: 5,
+          animated: false,
+          viewPosition: 0.5,
+        });
+      });
+      jest.advanceTimersByTime(50);
+
+      expect(scrollToEndSpy).not.toHaveBeenCalled();
+    });
+
+    it("fires scrollToEnd from the autoscroll path when isOffsetProjectionEnabled is true", () => {
+      const data = Array.from({ length: 20 }, (_, i) => i);
+      const { result, ref } = renderChatList(data);
+
+      const scrollToEndSpy = jest.fn();
+      const nativeScrollRef = ref.current?.getNativeScrollRef() as any;
+      expect(nativeScrollRef).toBeTruthy();
+      nativeScrollRef.scrollToEnd = scrollToEndSpy;
+
+      scrollTo(result, 1101);
+      jest.runAllTimers();
+      scrollToEndSpy.mockClear();
+
+      result.setProps({ data: [...data, 100] });
+      jest.runAllTimers();
+
+      expect(scrollToEndSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/recyclerview/hooks/useBoundDetection.ts
+++ b/src/recyclerview/hooks/useBoundDetection.ts
@@ -141,6 +141,14 @@ export function useBoundDetection<T>(
   }, [recyclerViewManager]);
 
   const runAutoScrollToBottomCheck = useCallback(() => {
+    // Suppress MVCP autoscroll while a programmatic scrollToIndex is in
+    // flight. FlashList disables offset projection at the start of
+    // scrollToIndex and reenables it ~200-300ms after settling. Without
+    // this guard, the sticky pendingAutoscrollToBottom ref races against
+    // scrollToIndex and fires scrollToEnd mid flight.
+    if (!recyclerViewManager.isOffsetProjectionEnabled) {
+      return;
+    }
     if (pendingAutoscrollToBottom.current) {
       pendingAutoscrollToBottom.current = false;
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Description

This PR fixes a race between imperative `scrollToIndex` and the MVCP autoscroll to bottom mechanism in v2. When `autoscrollToBottomThreshold` is set and the user is near the bottom of the list, calling [`scrollToIndex`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L320) imperatively can be hijacked by the autoscroll to bottom path mid scroll animation. The list briefly lands at the target index, then snaps back to the bottom.

This typically reproduces when list items are not fully stable, i.e they need to be remeasured/corrected often. In other words, something that would actually falsely trigger autoscrolling.

I've found this to be reliably reproducible in any chat style list with an actual `autoscrollToBottomThreshold` set to its MVCP that also has unstable items (i.e images or GIFs, but also items which might require additional correction internally so basically anything that would trigger any type of change in `contentSize`):

1. Open the list (lands at bottom)
2. Scroll up far enough that the target index has rendered and been measured at least once
3. Scroll back down to the bottom and sit still for >=100ms
4. Trigger `listRef.current?.scrollToIndex({ index: targetIndex, animated: true, viewPosition: 0.5 })` - typically from an effect or `setTimeout(0)` callback that's downstream of an unrelated state update (e.g., tapping a quoted message that first dispatches a "targeted message" state change)
5. List animates to `targetIndex`, then snaps back to the bottom

The race fires reliably only on the first attempt after step 3. Subsequent calls behave correctly: the race fired `scrollToEnd` refreshes the tracked anchor (via `computeFirstVisibleIndexForOffsetCorrection`), so subsequent `applyOffsetCorrection` diff calculations evaluate to ~0 and don't emit the stray `scrollBy`. A long enough wait at the bottom can make the snapshot stale again however, via background remeasurement and reproduce on a later attempt.

After a ton of debugging, I've found the root cause of this to actually be the two MVCP related subsystems interacting without coordinating:

**1. Autoscroll-to-bottom** lives in [`useBoundDetection.ts`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts). It maintains a sticky ref [`pendingAutoscrollToBottom`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L28), set `true` by [`checkBounds`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L55) whenever the user is within `autoscrollToBottomThreshold` viewports of the bottom. [`runAutoScrollToBottomCheck`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L143) fires `scrollToEnd` via [`requestAnimationFrame`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L154), driven by two effects:
- The [data change effect](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L173), keyed on `[data, runAutoScrollToBottomCheck, windowHeight, windowWidth]`.
- The [content geometry effect](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L178), keyed on `[contentHeight, contentWidth, recyclerViewManager.firstItemOffset, …]`, gated by a [100ms `lastCheckBoundsTime` guard](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L179) that I'm guessing is there to avoid firing during finger scroll.

**2. Anchor MVCP** lives in [`applyOffsetCorrection`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L119), runs on every layout commit and applies a compensating [`scrollBy(diff)`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L186) when its [tracked anchor item](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L58)'s cached layout snapshot diverges from the live layout. Gated by [`pauseOffsetCorrection.current`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L53). The anchor snapshot is refreshed at the end of each `applyOffsetCorrection` run via [`computeFirstVisibleIndexForOffsetCorrection`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L92) and at scroll momentumend via the same function.

So, the timeline of events looks something like this from my analysis:

- User is at the bottom; `pendingAutoscrollToBottom.current === true`. The user has been sitting still long enough that background remeasurement of items (async images, font metric resolution, estimates resolving into real measurements as items leave/enter the render window) has drifted some items' cached layouts relative to the snapshot captured by `computeFirstVisibleIndexForOffsetCorrection` at the last momentum end.
- An unrelated rerender commits typically from a state update in the integrating app (e.g., highlighting the targeted message). `pauseOffsetCorrection.current` is still `false` because `scrollToIndex` hasn't run yet - it lives downstream in a `setTimeout(0)` / effect / event-handler tick.
- During that commit, `applyOffsetCorrection` evaluates with the stale anchor snapshot, computes a nonzero `diff` and fires [`scrollAnchorRef.current?.scrollBy(diff)`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L186)
- The stray scroll mutates `contentHeight` / `firstItemOffset` over the next render, triggering the content change `useEffect` in `useBoundDetection`. `pendingAutoscrollToBottom.current` is still `true` (the >100ms `lastCheckBoundsTime` guard passes), then  `runAutoScrollToBottomCheck` fires, then `scrollToEnd` queued via `requestAnimationFrame`
- A tick later, `scrollToIndex` finally runs and sets [`setOffsetProjectionEnabled(false)`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L335) + `pauseOffsetCorrection.current = true`. Two scroll animations are now in flight; `scrollToEnd` typically wins.

### Fix

A single early return at the top of [`runAutoScrollToBottomCheck`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useBoundDetection.ts#L143-L156): bail when a programmatic `scrollToIndex` is in flight, signalled by FlashList's own [`recyclerViewManager.isOffsetProjectionEnabled`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/RecyclerViewManager.ts#L53-L55) getter, backed by [`engagedIndicesTracker.enableOffsetProjection`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/helpers/EngagedIndicesTracker.ts#L67) (default `true`).

```ts
const runAutoScrollToBottomCheck = useCallback(() => {
+ if (!recyclerViewManager.isOffsetProjectionEnabled) {
+   return;
+ }
  if (pendingAutoscrollToBottom.current) {
    pendingAutoscrollToBottom.current = false;
    requestAnimationFrame(() => {
      const shouldAnimate =
        recyclerViewManager.props.maintainVisibleContentPosition
          ?.animateAutoScrollToBottom ?? true;
      scrollViewRef.current?.scrollToEnd({
        animated: shouldAnimate && !recyclerViewManager.ignoreScrollEvents,
      });
    });
  }
}, [requestAnimationFrame, scrollViewRef, recyclerViewManager]);
```

`isOffsetProjectionEnabled` is already toggled `false` at [the start of `scrollToIndex`](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L335) and back to `true` ~200–300ms after the scroll settles ([here](https://github.com/Shopify/flash-list/blob/main/src/recyclerview/hooks/useRecyclerViewController.tsx#L487-L488)). That window covers the entire `scrollToIndex` operation and its settling tail, during which `applyOffsetCorrection` can continue to emit corrective scrolls. If it fits the usecase better I can possibly introduce a separate ref that is going to have purely this as its responsibility.

The autoscroll to bottom contract should be *"if the user is at the bottom and new content arrives, stay at the bottom."* When an imperative scroll has explicitly reassigned the scroll position, "stay at the bottom" no longer applies for the duration of that operation. Suppressing autoscroll while imperative scrolling owns the position should be the correct semantic in my opinion.

I've also included a new fixture that reproduces this consistently (just load all of the items up until the middle and try scrolling to bottom and then to the item using the buttons. Needed to do this because of how stable the example is and it wouldn't reproduce on items that don't particularly drift at any point. 

## Reviewers’ hat-rack :tophat:

- [ ] The guard predicate (`!recyclerViewManager.isOffsetProjectionEnabled`) is the right signal vs. alternatives like `pauseOffsetCorrection.current` or a new dedicated flag
- [ ] No other call site of `runAutoScrollToBottomCheck` or path into autoscroll is unintentionally suppressed by this guard. `isOffsetProjectionEnabled` is only flipped inside `scrollToIndex`, so the window is precisely the imperative scroll lifetime + settle
- [ ] Confirm the "stay at bottom on new content arriving during a programmatic scroll" behavior change is acceptable - during the 200-300ms settling tail of a `scrollToIndex`, newly arrived data won't trigger autoscroll. Autoscroll resumes when the flag flips back
- [ ] Confirm the issue is reproducible through the fixture screen

## Screenshots or videos (if needed)

Before:

https://github.com/user-attachments/assets/6e192187-60de-40fd-99c0-efc38e76bc1a

(I forgot to add feedback on clicking the buttons but essentially I'm just pressing on the `scrollToIndex` button and it succeeds only once)

After:

https://github.com/user-attachments/assets/e9054b92-c518-431e-b0a2-32a064f29570

(same drill, except it succeeds all times)


