### PR TITLE
fix(android): use unstable_getBoundingClientRect for synchronous layout measurement on New Architecture

### DIFF
--- a/src/recyclerview/utils/measureLayout.ts
+++ b/src/recyclerview/utils/measureLayout.ts
@@ -1,5 +1,15 @@
 import { PixelRatio, View } from "react-native";
 
+// unstable_getBoundingClientRect is not part of the official RN View type yet
+type ViewWithBoundingClientRect = View & {
+  unstable_getBoundingClientRect?: () => {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+};
+
 interface Layout {
   x: number;
   y: number;
@@ -21,10 +31,29 @@ interface Size {
  * @returns An object containing x, y, width, and height measurements
  */
 function measureLayout(view: View, oldLayout: Layout | undefined) {
-  // const layout = view.unstable_getBoundingClientRect();
-  // layout.width = roundOffPixel(layout.width);
-  // layout.height = roundOffPixel(layout.height);
-  // return layout;
+  // On Android New Architecture (RN 0.78+), View.measureLayout() invokes its
+  // callback asynchronously, so by the time we return `layout` the values are
+  // still {0,0,0,0}.  unstable_getBoundingClientRect() reads directly from the
+  // Fabric shadow tree and is synchronous, so use it when available.
+  const viewWithRect = view as ViewWithBoundingClientRect;
+  if (typeof viewWithRect.unstable_getBoundingClientRect === "function") {
+    const rect = viewWithRect.unstable_getBoundingClientRect();
+    const layout: Layout = {
+      x: rect.x ?? 0,
+      y: rect.y ?? 0,
+      width: roundOffPixel(rect.width ?? 0),
+      height: roundOffPixel(rect.height ?? 0),
+    };
+    if (oldLayout) {
+      if (areDimensionsEqual(layout.width, oldLayout.width)) {
+        layout.width = oldLayout.width;
+      }
+      if (areDimensionsEqual(layout.height, oldLayout.height)) {
+        layout.height = oldLayout.height;
+      }
+    }
+    return layout;
+  }
   return measureLayoutRelative(view, view, oldLayout);
 }
 


### PR DESCRIPTION
## Description

Fixes FlashList rendering nothing on Android New Architecture (RN 0.78+).

### Root cause

`View.measureLayout()` on Android New Architecture invokes its callback **asynchronously** — it returns before the callback fires. `measureLayout()` in `measureLayout.ts` calls it, then immediately returns the local `layout` object, which is still `{x:0, y:0, width:0, height:0}`.

This means `measureParentSize()` always returns `{width:0, height:0}`, so `recyclerViewManager.updateLayoutParams()` is called with a window height of 0. FlashList never renders any items.

The `onLayout` event detects that the stored container size (`containerViewSizeRef`) is 0 and calls `recyclerViewContext.layout()` to trigger a re-render — but `useLayoutEffect` runs `measureLayout` again with the same async/0 result, creating an **infinite re-render loop** that never resolves.

### Fix

`unstable_getBoundingClientRect()` reads directly from the Fabric shadow tree and is **synchronous** on New Architecture (RN 0.78+). Use it in `measureLayout` when available, and fall back to `measureLayoutRelative` on Old Architecture where the method doesn't exist.

The commented-out code at the top of `measureLayout()` pointed at this same API. This PR restores that intent with proper type safety and an Old Arch fallback.

### Relationship to #2269

PR #2269 adds an early return when the container measures 0x0 (a different scenario: transient zero measurements during navigation stack transitions on web). Our fix addresses a separate root cause: the measurement itself never returns a non-zero value on Android New Arch. These two fixes are complementary.

### Testing

Verified on Android with React Native 0.85 + New Architecture enabled. FlashList renders items correctly after this change. Without it, the list is permanently blank.

## Checklist

- [x] Tested on Android New Architecture (RN 0.85)
- [x] Falls back to `measureLayoutRelative` on Old Architecture
- [x] TypeScript: `unstable_getBoundingClientRect` is not on the public `View` type — added a local `ViewWithBoundingClientRect` type cast