### PR TITLE
fix(layout): guard validateItemSize against stale onLayout indices

### DIFF
--- a/src/__tests__/RecyclerViewManager.test.ts
+++ b/src/__tests__/RecyclerViewManager.test.ts
@@ -2,6 +2,11 @@ import { RecyclerViewManager } from "../recyclerview/RecyclerViewManager";
 import { WarningMessages } from "../errors/WarningMessages";
 import { FlashListProps } from "../FlashListProps";
 
+import {
+  createPopulatedLayoutManager,
+  LayoutManagerType,
+} from "./helpers/createLayoutManager";
+
 describe("RecyclerViewManager", () => {
   let consoleWarnSpy: jest.SpyInstance;
 
@@ -13,18 +18,18 @@ describe("RecyclerViewManager", () => {
     consoleWarnSpy.mockRestore();
   });
 
+  const createMockProps = (overrides = {}) =>
+    ({
+      data: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      renderItem: jest.fn(),
+      ...overrides,
+    } as FlashListProps<unknown>);
+
+  const createManager = (props: FlashListProps<unknown>) => {
+    return new RecyclerViewManager(props);
+  };
+
   describe("keyExtractor warning with maintainVisibleContentPosition", () => {
-    const createMockProps = (overrides = {}) =>
-      ({
-        data: [{ id: 1 }, { id: 2 }, { id: 3 }],
-        renderItem: jest.fn(),
-        ...overrides,
-      } as FlashListProps<unknown>);
-
-    const createManager = (props: FlashListProps<unknown>) => {
-      return new RecyclerViewManager(props);
-    };
-
     it("should warn when onStartReached is defined but keyExtractor is not", () => {
       const props = createMockProps({
         onStartReached: jest.fn(),
@@ -69,6 +74,30 @@ describe("RecyclerViewManager", () => {
       createManager(props);
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("tryGetLayout boundary handling", () => {
+    it("should return undefined when no layoutManager has been initialized", () => {
+      const manager = createManager(createMockProps());
+
+      expect(manager.tryGetLayout(0)).toBeUndefined();
+      expect(manager.tryGetLayout(999)).toBeUndefined();
+      expect(manager.tryGetLayout(-1)).toBeUndefined();
+    });
+
+    it("should return undefined for an index beyond the current layout count", () => {
+      const manager = createManager(createMockProps());
+      const layoutManager = createPopulatedLayoutManager(
+        LayoutManagerType.LINEAR,
+        5
+      );
+      (manager as any).layoutManager = layoutManager;
+
+      expect(manager.tryGetLayout(2)).toBeDefined();
+      expect(manager.tryGetLayout(5)).toBeUndefined();
+      expect(manager.tryGetLayout(10)).toBeUndefined();
+      expect(manager.tryGetLayout(-1)).toBeUndefined();
     });
   });
 });

--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -373,7 +373,10 @@ const RecyclerViewComponent = <T,>(
    */
   const validateItemSize = useCallback(
     (index: number, size: RVDimension) => {
-      const layout = recyclerViewManager.getLayout(index);
+      const layout = recyclerViewManager.tryGetLayout(index);
+      if (!layout) {
+        return;
+      }
       const width = Math.max(
         Math.min(layout.width, layout.maxWidth ?? Infinity),
         layout.minWidth ?? 0


### PR DESCRIPTION
## Description

Fixes #2291

`ViewHolder.onLayout` can fire after the list's layout table has changed during fast data updates or navigation. `validateItemSize` was calling `getLayout(index)`, which throws when the render-time index is no longer valid in the layout manager.

Switch to `tryGetLayout(index)` and return early when it is `undefined`. Same pattern as `StickyHeaders` and `useRecyclerViewController`.

The same fix is running in production via Expensify's local patch (Expensify/App#91248).

## Reviewers' hat-rack :tophat:

- `RecyclerView.tsx`: 1-line change, swap to `tryGetLayout` + early return
- `RecyclerViewManager.test.ts`: helpers lifted to parent describe, two boundary tests added

## Test plan

- `yarn test --forceExit` — 187 tests pass, including 2 new boundary tests for `tryGetLayout`
- `yarn type-check` passes
- `yarn lint` passes
- `yarn build` passes