### PR TITLE
fix(inverted): force `firstItemOffset` to 0 for inverted lists

### DIFF
--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -175,9 +175,10 @@ const RecyclerViewComponent = <T,>(
 
       // firstChildViewLayout is already relative to the outer container,
       // so its x/y directly gives the first item offset.
-      const firstItemOffset = horizontal
+      const axisOffset = horizontal
         ? firstChildViewLayout.x
         : firstChildViewLayout.y;
+      const firstItemOffset = inverted ? 0 : axisOffset;
 
       // Update the RecyclerView manager with window dimensions
       recyclerViewManager.updateLayoutParams(


### PR DESCRIPTION
## Description

### Problem                                                                                                                                                           

Inverted FlashList only renders a few items, _leaving the rest of the viewport as white space while scrolling_.                                                       

`RecyclerView` measures `firstItemOffset` by calling `measureFirstChildLayout` relative to the outer container. When _inverted_ is true, the outer container has a `scaleY: -1` transform applied, which flips the coordinate system. As a result, the measured y-offset comes back equal to the container height instead of 0.                  

That bad offset propagates through `adjustedOffset = scrollOffset - firstItemOffset`, pushing every adjusted scroll position into negative space where no items live. 
Only the handful of items caught by the draw-distance buffer ever render — everything else stays blank. 

**Reproduction stack:** https://snack.expo.dev/@vikstash/inverted-flashlist-bug

**Steps:**
1. Open an `inverted` list with 50 items.
2. Scroll to top.
3. See the 35th+ items are not rendered at all, and blank space displays.

<details>
<summary>Bug video:</summary>

https://github.com/user-attachments/assets/74c0b927-89e2-410a-bc46-08af32c00334

</details>

### Solution                                                                                                                                                            
                                                                                                                                                                      
Force `firstItemOffset` to 0 when inverted is true. The `scaleY: -1` transform already handles the visual inversion, so the raw offset measured against the flipped coordinate system isn't needed (and is actively wrong). 

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ] Render an inverted FlashList and confirm the full viewport is filled with items (not just the draw-distance buffer)
- [ ] Verify a non-inverted vertical FlashList still renders and scrolls correctly (no regression to the default path) 
