### PR TITLE
fix(inverted): align ItemSeparatorComponent's trailingItem with visual flow

### DIFF
--- a/src/__tests__/RecyclerView.test.tsx
+++ b/src/__tests__/RecyclerView.test.tsx
@@ -209,6 +209,75 @@ describe("RecyclerView", () => {
     });
   });
 
+  describe("Item separators in inverted mode", () => {
+    const Separator = (props: {
+      leadingItem?: number;
+      trailingItem?: number;
+    }) => (
+      <View style={{ height: 10 }}>
+        <Text>{`sep:${props.leadingItem}-${props.trailingItem}`}</Text>
+      </View>
+    );
+
+    it("passes the visually-adjacent item as trailingItem in inverted mode", () => {
+      // In inverted layout the cell at data[i] visually sits ABOVE the cell at
+      // data[i-1] (index 0 = visual bottom). A separator owned by cell `i`
+      // visually appears between cell `i` and cell `i-1`, so `trailingItem`
+      // must be `data[i-1]` to stay semantically aligned with the visually
+      // adjacent item below the separator.
+      const result = render(
+        <FlashList
+          inverted
+          data={[10, 20, 30]}
+          overrideProps={{ initialDrawBatchSize: 1 }}
+          drawDistance={0}
+          renderItem={({ item }) => <Text>{item}</Text>}
+          ItemSeparatorComponent={Separator}
+        />
+      );
+
+      // Three items, two separators (no separator below index 0 = visual bottom).
+      const separators = result.findAll(Separator);
+      expect(separators.length).toBe(2);
+
+      // Separator inside cell at array index 1 (data=20) should have
+      // leading=20 (cell's own item) and trailing=10 (data[i-1], visually below).
+      expect(result).toContainReactComponent(Separator, {
+        leadingItem: 20,
+        trailingItem: 10,
+      });
+
+      // Separator inside cell at array index 2 (data=30) should have
+      // leading=30 and trailing=20 (visually below).
+      expect(result).toContainReactComponent(Separator, {
+        leadingItem: 30,
+        trailingItem: 20,
+      });
+    });
+
+    it("does not render a separator below the visual-bottom item (index 0) in inverted mode", () => {
+      const result = render(
+        <FlashList
+          inverted
+          data={[10, 20]}
+          overrideProps={{ initialDrawBatchSize: 1 }}
+          drawDistance={0}
+          renderItem={({ item }) => <Text>{item}</Text>}
+          ItemSeparatorComponent={Separator}
+        />
+      );
+
+      // Two items: only one separator (between data[1] above and data[0] below).
+      // No separator at index 0 since there's nothing visually below it.
+      const separators = result.findAll(Separator);
+      expect(separators.length).toBe(1);
+      expect(result).toContainReactComponent(Separator, {
+        leadingItem: 20,
+        trailingItem: 10,
+      });
+    });
+  });
+
   describe("Viewability with initialScrollIndex", () => {
     const scrollTo = (root: ReturnType<typeof render>, y: number) => {
       const scrollable = root.findWhere((node: any) => node.props.onScroll);

--- a/src/recyclerview/ViewHolderCollection.tsx
+++ b/src/recyclerview/ViewHolderCollection.tsx
@@ -180,10 +180,23 @@ export const ViewHolderCollection = <TItem,>(
           // Suppress separators for items in the last row to prevent
           // height mismatch. The last data item has no separator (no
           // trailingItem), so all items sharing its row must match.
-          const trailingItem =
-            ItemSeparatorComponent && !isInLastRow(index)
+          //
+          // In `inverted` mode the cell is positioned in reverse visual
+          // order, so `data[index + 1]` is no longer the item visually
+          // adjacent to the separator — `data[index - 1]` is. Swap the
+          // computation so `trailingItem` stays semantically aligned with
+          // the visually-adjacent item below the separator, regardless of
+          // orientation. For inverted there's also no separator below the
+          // very-first item (index 0 = visual bottom).
+          const trailingItem = ItemSeparatorComponent
+            ? inverted
+              ? index > 0
+                ? data[index - 1]
+                : undefined
+              : !isInLastRow(index)
               ? data[index + 1]
-              : undefined;
+              : undefined
+            : undefined;
 
           return (
             <ViewHolder


### PR DESCRIPTION
## Summary

`ItemSeparatorComponent` is documented to receive `{ leadingItem, trailingItem }` so consumers can render context-aware separators (think: "small gap between same-sender chat bubbles, larger gap on sender switch"). In the default layout the prop names match the **visual** flow — `leadingItem` is the cell above the separator, `trailingItem` is the cell below.

In `inverted` mode this assumption breaks: cells are positioned in reverse visual order (array index 0 is at the visual bottom), so the separator owned by cell `i` visually appears between `data[i]` (above) and `data[i - 1]` (below). The current code still passes `data[index + 1]` as `trailingItem`, which is the cell two rows away — not the visually-adjacent neighbor below the separator. Anyone comparing `leadingItem` vs `trailingItem` in an inverted list ends up looking at the wrong pair.

This is most painful in chat UIs (`inverted` is the canonical layout for chronological chat lists). Imagine bubbles `[user, user, expert]` in chronological reading. With newest-first data + `inverted`, the array is `[expert, user, user]`. The separator inside the middle cell (`leading=user`, `trailing=user` via `data[i+1]`) says "same sender → 4px gap". But the visually-adjacent items around that separator are the top user bubble and the expert bubble — different senders, should be 24px. The result is a 4px gap where the user expects 24px.

## Fix

In `ViewHolderCollection.tsx`, branch on `inverted`:

```ts
// Before
const trailingItem =
  ItemSeparatorComponent && !isInLastRow(index)
    ? data[index + 1]
    : undefined;

// After
const trailingItem = ItemSeparatorComponent
  ? inverted
    ? index > 0
      ? data[index - 1]
      : undefined
    : !isInLastRow(index)
      ? data[index + 1]
      : undefined
  : undefined;
```

- Inverted mode: `trailingItem = data[index - 1]` so it stays semantically aligned with the visually-adjacent item below the separator.
- Inverted mode: skip the separator at `index === 0` (visual-bottom cell has no neighbor below it). This mirrors the existing `!isInLastRow(index)` guard for the default case.
- Non-inverted behavior is unchanged.

## Tests

Added two cases in `src/__tests__/RecyclerView.test.tsx → "Item separators in inverted mode"`:

1. `passes the visually-adjacent item as trailingItem in inverted mode` — renders an inverted list with `data=[10, 20, 30]` and asserts the separators carry `{ leading: 20, trailing: 10 }` and `{ leading: 30, trailing: 20 }` (the visually-adjacent pair below each separator). Without the fix this would assert wrong values.
2. `does not render a separator below the visual-bottom item (index 0)` — renders `data=[10, 20]` and asserts only one separator is rendered (between data[1] above and data[0] below); no separator dangling at the visual bottom.

All existing tests still pass (24 total in `RecyclerView.test.tsx`).

## Notes

- The behavioral change is opt-in (only triggers when `inverted: true`), so existing non-inverted consumers see no difference.
- For inverted lists that previously got "wrong-pair" `trailingItem` values, this is a bug fix that may cause visible spacing changes in their separators. The new values match what most consumers actually intend by "between this cell and the next visible one."

## Test plan

- [x] `yarn test --testPathPattern=RecyclerView` — 24/24 pass
- [x] `yarn lint` — clean