### PR TITLE
fix(inverted): keep scrollbar on the right on Android

### DIFF
--- a/src/native/config/PlatformHelper.android.ts
+++ b/src/native/config/PlatformHelper.android.ts
@@ -5,13 +5,15 @@ const PlatformConfig = {
   supportsOffsetCorrection: true,
   trackAverageRenderTimeForOffsetProjection: true,
   isRN083OrAbove: isRN083OrAbove(),
-  // Using rotate instead of scaleY on Android to avoid performance issues.
-  // Caveat: this causes the scrollbar to appear on the left side.
-  // Issue: https://github.com/Shopify/flash-list/issues/751
-  invertedTransformStyle: { transform: [{ rotate: "180deg" }] } as const,
-  invertedTransformStyleHorizontal: {
-    transform: [{ rotate: "180deg" }],
-  } as const,
+  // Use scaleY/scaleX to invert (matching iOS and web) so the native scrollbar
+  // stays on the correct edge. The previous `rotate("180deg")` workaround also
+  // mirrored the horizontal axis, which pushed the scrollbar to the wrong side
+  // (https://github.com/Shopify/flash-list/issues/751). `rotate` was originally
+  // chosen for v1 scroll performance, but that jank came from native subview
+  // clipping; v2 disables it (`removeClippedSubviews={false}`), so scaleY no
+  // longer regresses scrolling.
+  invertedTransformStyle: { transform: [{ scaleY: -1 }] } as const,
+  invertedTransformStyleHorizontal: { transform: [{ scaleX: -1 }] } as const,
 };
 
 export { PlatformConfig };


### PR DESCRIPTION
## Description


  When `inverted` is used on Android, the vertical scrollbar appears on the **left**
  edge instead of the right (iOS and web are unaffected).

  **Root cause:** Android inverted the list with `transform: rotate("180deg")`, while
  iOS/web use `scaleY: -1`. A 180° rotation mirrors **both** axes — the vertical flip
  is the inversion we want, but the horizontal mirror drags the native scrollbar to the
  wrong edge (left for vertical lists, top for horizontal lists).

  **Fix:** Switch Android to `scaleY: -1` / `scaleX: -1`, matching iOS and web, so only
  the relevant axis is flipped and the scrollbar stays on the correct edge. `rotate` was
  originally chosen for v1 scroll performance, but that jank came from native subview
  clipping, which v2 already disables (`removeClippedSubviews={false}`) — so `scaleY` no
  longer regresses scrolling.

  Affected package: `@shopify/flash-list`. The change is a single value in
  `src/native/config/PlatformHelper.android.ts`; all consumers (list container, items,
  header/footer, sticky headers) read it through the existing `getInvertedTransformStyle`
  helper, so they stay consistent automatically.

  ## Reviewers' hat-rack 🎩

  - [ ] Confirm on an Android device/emulator that an inverted list now shows the scrollbar
        on the **right**, with items, header, footer, separators, and **sticky headers**
        unchanged.
  - [ ] Sanity-check scroll smoothness on Android (no regression vs. the old `rotate` path).
  - [ ] Verify iOS/web are unchanged (they already used `scaleY`/`scaleX`).
