### PR TITLE
feat(sticky-headers): configure sticky header zIndex

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -332,6 +332,7 @@ stickyHeaderConfig?: {
   useNativeDriver?: boolean;
   offset?: number;
   backdropComponent?: React.ComponentType<any> | React.ReactElement | null;
+  zIndex?: number;
   hideRelatedCell?: boolean;
 };
 ```
@@ -365,6 +366,14 @@ Useful for creating visual separation or effects like backgrounds with blur.
 backdropComponent?: React.ComponentType<any> | React.ReactElement | null;
 ```
 
+#### `zIndex`
+
+zIndex applied to the sticky header container. Default is `2`.
+
+```tsx
+zIndex?: number;
+```
+
 #### `hideRelatedCell`
 
 When a sticky header is displayed, the cell associated with it is hidden.
@@ -384,6 +393,7 @@ hideRelatedCell?: boolean;
     useNativeDriver: true,
     offset: 50, // Headers stick 50px from top
     backdropComponent: <BlurView style={StyleSheet.absoluteFill} />,
+    zIndex: 3,
     hideRelatedCell: true,
   }}
   renderItem={({ item }) => <ListItem item={item} />}

--- a/src/FlashListProps.ts
+++ b/src/FlashListProps.ts
@@ -452,6 +452,12 @@ export interface FlashListProps<TItem>
           | undefined;
 
         /**
+         * zIndex applied to the sticky header container.
+         * @default 2
+         */
+        zIndex?: number;
+
+        /**
          * When a sticky header is displayed, the cell associated with it is hidden.
          * @default false
          */

--- a/src/__tests__/RecyclerView.test.tsx
+++ b/src/__tests__/RecyclerView.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from "react";
-import { Text, View } from "react-native";
+import { Animated, Text, View } from "react-native";
 import "@quilted/react-testing/matchers";
 import { render } from "@quilted/react-testing";
 
@@ -75,6 +75,28 @@ describe("RecyclerView", () => {
 
       expect(result).toContainReactComponent(Text, { children: 0 });
       expect(result).not.toContainReactComponent(Text, { children: 11 });
+    });
+  });
+
+  describe("Sticky header config", () => {
+    it("applies configured sticky header zIndex", () => {
+      const result = render(
+        <FlashList
+          data={[0, 1, 2]}
+          renderItem={({ item }) => <Text>{item}</Text>}
+          stickyHeaderIndices={[0]}
+          stickyHeaderConfig={{ zIndex: 0 }}
+          overrideProps={{ initialDrawBatchSize: 1 }}
+          drawDistance={0}
+        />
+      );
+
+      const animatedView = result.find(Animated.View);
+      expect(animatedView).toHaveReactProps({
+        style: expect.objectContaining({
+          zIndex: 0,
+        }),
+      });
     });
   });
 

--- a/src/__tests__/StickyHeaders.test.tsx
+++ b/src/__tests__/StickyHeaders.test.tsx
@@ -640,5 +640,36 @@ describe("StickyHeaders - Compute Function", () => {
         }),
       });
     });
+
+    it("should render sticky header with configured zIndex", () => {
+      const layouts = createStandardLayouts();
+
+      const manager = createMockRecyclerViewManager({
+        scrollOffset: 100,
+        layouts,
+      });
+
+      const result = render(
+        <StickyHeaders
+          stickyHeaderIndices={[0, 10, 20]}
+          stickyHeaderOffset={0}
+          stickyHeaderZIndex={7}
+          data={testData}
+          scrollY={new Animated.Value(0)}
+          renderItem={renderItem}
+          stickyHeaderRef={createRef()}
+          recyclerViewManager={manager}
+          extraData={undefined}
+          onChangeStickyIndex={jest.fn()}
+        />
+      );
+
+      const animatedView = result.find(Animated.View);
+      expect(animatedView).toHaveReactProps({
+        style: expect.objectContaining({
+          zIndex: 7,
+        }),
+      });
+    });
   });
 });

--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -101,6 +101,7 @@ const RecyclerViewComponent = <T,>(
     stickyHeaderConfig?.useNativeDriver ?? true;
   const stickyHeaderHideRelatedCell =
     stickyHeaderConfig?.hideRelatedCell ?? false;
+  const stickyHeaderZIndex = stickyHeaderConfig?.zIndex ?? 2;
 
   // Compute the inverted transform style based on platform and orientation
   const invertedTransformStyle = inverted
@@ -438,6 +439,7 @@ const RecyclerViewComponent = <T,>(
           renderItem={renderItem}
           scrollY={scrollY}
           stickyHeaderRef={stickyHeaderRef}
+          stickyHeaderZIndex={stickyHeaderZIndex}
           recyclerViewManager={recyclerViewManager}
           extraData={extraData}
           inverted={inverted}
@@ -463,6 +465,7 @@ const RecyclerViewComponent = <T,>(
     currentStickyIndex,
     onChangeStickyIndex,
     stickyHeaderHideRelatedCell,
+    stickyHeaderZIndex,
     inverted,
   ]);
 

--- a/src/recyclerview/components/StickyHeaders.tsx
+++ b/src/recyclerview/components/StickyHeaders.tsx
@@ -40,6 +40,8 @@ export interface StickyHeaderProps<TItem> {
   renderItem: FlashListProps<TItem>["renderItem"];
   /** Ref to access sticky header methods */
   stickyHeaderRef: React.RefObject<StickyHeaderRef>;
+  /** zIndex applied to the sticky header container */
+  stickyHeaderZIndex?: number;
   /** Manager for recycler view operations */
   recyclerViewManager: RecyclerViewManager<TItem>;
   /** Additional data to trigger re-renders */
@@ -72,6 +74,7 @@ export const StickyHeaders = <TItem,>({
   extraData,
   onChangeStickyIndex,
   inverted,
+  stickyHeaderZIndex = 2,
 }: StickyHeaderProps<TItem>) => {
   const [stickyHeaderState, setStickyHeaderState] = useState<StickyHeaderState>(
     {
@@ -87,13 +90,13 @@ export const StickyHeaders = <TItem,>({
     return [...stickyHeaderIndices].sort((first, second) => first - second);
   }, [stickyHeaderIndices]);
 
-  const legthInvalid =
+  const lengthInvalid =
     sortedIndices.length === 0 ||
     recyclerViewManager.getDataLength() <=
       sortedIndices[sortedIndices.length - 1];
 
   const compute = useCallback(() => {
-    if (legthInvalid) {
+    if (lengthInvalid) {
       return;
     }
     const adjustedScrollOffset = recyclerViewManager.getLastScrollOffset();
@@ -139,7 +142,7 @@ export const StickyHeaders = <TItem,>({
       onChangeStickyIndex?.(newStickyIndex);
     }
   }, [
-    legthInvalid,
+    lengthInvalid,
     recyclerViewManager,
     sortedIndices,
     currentStickyIndex,
@@ -201,7 +204,7 @@ export const StickyHeaders = <TItem,>({
           top: stickyHeaderOffset,
           left: 0,
           right: 0,
-          zIndex: 2,
+          zIndex: stickyHeaderZIndex,
           transform: [{ translateY }],
           opacity,
         }}
@@ -231,6 +234,7 @@ export const StickyHeaders = <TItem,>({
     refHolder,
     extraData,
     stickyHeaderOffset,
+    stickyHeaderZIndex,
     inverted,
   ]);
 


### PR DESCRIPTION
## Description                                                                                                                                                                                                  
                                                                                                                                                                                                               
Fixes N/A                                                                                                                                                                                                       
                                                                                                                                                                                                               
Adds a `zIndex` option to `stickyHeaderConfig` for `@shopify/flash-list`, allowing callers to configure the stacking order of the sticky header container. The default remains `2`, preserving existing         
behavior when the option is not provided.                                                                                                                                                                         
                                                                                                                                                                                                               
## Reviewers’ hat-rack :tophat:                                                                                                                                                                                 
                                                                                                                                                                                                               
- [ ] Verify the `zIndex` option is plumbed correctly from `FlashList` props through `RecyclerView` into `StickyHeaders`.                                                                                       
- [ ] Confirm the default sticky header zIndex remains unchanged when `stickyHeaderConfig.zIndex` is omitted.                                                                                                   
- [ ] Tests run: `pnpm dlx yarn@1.22.17 type-check`, `pnpm dlx yarn@1.22.17 lint`, `pnpm dlx yarn@1.22.17 test --forceExit`, `pnpm dlx yarn@1.22.17 build`.                                                     
                                                                                                                                                                                                               
## Screenshots or videos (if needed)                                                                                                                                                                            
                                                                                                                                                                                                               
Not needed; this is a configuration/API change covered by tests.  
