### PR TITLE
fix(layout): keep layout table monotonic on initial scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fix wrong items rendered with `initialScrollIndex` when item size exceeds the default average estimate
+  - https://github.com/Shopify/flash-list/issues/2307
 - Introduce optional view offset param for initial scroll position
   - https://github.com/Shopify/flash-list/pull/1870
 - Add sticky header offset and sticky header backgrounds

--- a/src/__tests__/InitialScrollIndexLargeItems.test.tsx
+++ b/src/__tests__/InitialScrollIndexLargeItems.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Text } from "react-native";
+import "@quilted/react-testing/matchers";
+import { render } from "@quilted/react-testing";
+
+import { FlashList } from "..";
+
+// Items measure at 300px — larger than the layout managers' default
+// 200px average estimate. Reproduces #2307: the initial-scroll corrective
+// pass used to leave items beyond initialScrollIndex at stale positions,
+// breaking the layout table's monotonicity and rendering the wrong items.
+jest.mock("../recyclerview/utils/measureLayout", () => {
+  const originalModule = jest.requireActual(
+    "../recyclerview/utils/measureLayout"
+  );
+  return {
+    ...originalModule,
+    measureParentSize: jest.fn().mockImplementation(() => ({
+      width: 399,
+      height: 899,
+    })),
+    measureFirstChildLayout: jest.fn().mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      width: 399,
+      height: 899,
+    })),
+    measureItemLayout: jest.fn().mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      width: 399,
+      height: 300,
+    })),
+  };
+});
+
+describe("initialScrollIndex with items larger than the default estimate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  it("renders the requested item when item size exceeds the average estimate", () => {
+    const data = Array.from({ length: 500 }, (_, index) => index);
+
+    const result = render(
+      <FlashList
+        data={data}
+        initialScrollIndex={250}
+        overrideProps={{ initialDrawBatchSize: 1 }}
+        drawDistance={0}
+        renderItem={({ item }) => <Text>{item}</Text>}
+      />
+    );
+
+    jest.runAllTimers();
+
+    // The list should open at item 250 — not ~83 indices further down,
+    // which is what a non-monotonic layout table produces.
+    expect(result).toContainReactComponent(Text, { children: 250 });
+    expect(result).not.toContainReactComponent(Text, { children: 333 });
+  });
+});

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -385,7 +385,12 @@ export class RecyclerViewManager<T> {
       // re-estimate unmeasured items with an updated average height, changing
       // the target item's position. Reading before recompute would capture a
       // stale offset, causing the wrong items to be rendered.
-      this.layoutManager.recomputeLayouts(0, initialScrollIndex);
+      // The recompute must cover the entire table, not just up to
+      // initialScrollIndex: moving items 0..initialScrollIndex while leaving
+      // later items at positions derived from older estimates can make the
+      // table non-monotonic, which breaks the binary search over item
+      // positions and renders the wrong items (#2307).
+      this.layoutManager.recomputeLayouts(0, this.getDataLength() - 1);
       const initialItemLayout =
         this.layoutManager.getLayout(initialScrollIndex);
       const initialItemOffset = this.propsRef.horizontal


### PR DESCRIPTION
## Description

Fixes #2307.

With `initialScrollIndex` set and items whose real size exceeds the layout managers' default 200px average estimate, the list opens showing the wrong items (e.g. item 333 instead of 250 with 300px items).

Root cause: `applyInitialScrollAdjustment` recomputes layouts only over `0..initialScrollIndex` before reading the target offset. When the average estimate has been updated by a first measurement, that pass moves items `0..initialScrollIndex` to new (larger) positions, while items beyond `initialScrollIndex` keep positions derived from the old estimate. The layout table becomes non-monotonic at the `initialScrollIndex` boundary (e.g. `75,000 → 50,400`), and the binary search over item positions then resolves the scroll offset to the wrong region of the table.

The fix recomputes the entire table in this pass, keeping it monotonic. This path only runs during the initial progressive-render passes (`renderProgressively` until the first layout completes), and the recompute is a simple position chain, so the cost class is unchanged from the existing `0..initialScrollIndex` pass.

## Reviewers’ hat-rack

- The measurement path (`modifyLayout`) already recomputes to the end of the table when items are appended; only this initial-scroll corrective pass stopped early.
- Items smaller than the estimate don't trigger the bug (the corrective pass moves items to *lower* positions, which keeps the table sorted) — matching the issue's observation that only sizes > 200px reproduce it.

## Test plan

- New test `src/__tests__/InitialScrollIndexLargeItems.test.tsx`: 500 items measuring 300px with `initialScrollIndex={250}`.
  - **Before the fix** it fails exactly as reported in #2307: items 333–335 are rendered instead of 250.
  - **After the fix** item 250 renders.
- `yarn test --forceExit` — 15 suites, 188 tests pass.
- `yarn type-check` and `yarn lint` — clean.
