### PR TITLE
fix(ci): restrict agent workflows to Talha

### DIFF
--- a/.github/workflows/agent-android-bot.yml
+++ b/.github/workflows/agent-android-bot.yml
@@ -42,14 +42,18 @@ jobs:
   bot:
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      github.actor == 'naqvitalha' &&
+      github.triggering_actor == 'naqvitalha' &&
       (
-        contains(github.event.comment.body || github.event.review.body, '@android-agent') &&
-        !contains(github.event.comment.body || github.event.review.body, '/fix') &&
+        github.event_name == 'workflow_dispatch' ||
         (
-          (github.event.comment.author_association || github.event.review.author_association) == 'OWNER' ||
-          (github.event.comment.author_association || github.event.review.author_association) == 'MEMBER' ||
-          (github.event.comment.author_association || github.event.review.author_association) == 'COLLABORATOR'
+          contains(github.event.comment.body || github.event.review.body, '@android-agent') &&
+          !contains(github.event.comment.body || github.event.review.body, '/fix') &&
+          (
+            (github.event.comment.author_association || github.event.review.author_association) == 'OWNER' ||
+            (github.event.comment.author_association || github.event.review.author_association) == 'MEMBER' ||
+            (github.event.comment.author_association || github.event.review.author_association) == 'COLLABORATOR'
+          )
         )
       )
     steps:

--- a/.github/workflows/agent-bot.yml
+++ b/.github/workflows/agent-bot.yml
@@ -39,14 +39,18 @@ jobs:
   bot:
     runs-on: macos-latest
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      github.actor == 'naqvitalha' &&
+      github.triggering_actor == 'naqvitalha' &&
       (
-        contains(github.event.comment.body || github.event.review.body, '@agent') &&
-        !contains(github.event.comment.body || github.event.review.body, '/fix') &&
+        github.event_name == 'workflow_dispatch' ||
         (
-          (github.event.comment.author_association || github.event.review.author_association) == 'OWNER' ||
-          (github.event.comment.author_association || github.event.review.author_association) == 'MEMBER' ||
-          (github.event.comment.author_association || github.event.review.author_association) == 'COLLABORATOR'
+          contains(github.event.comment.body || github.event.review.body, '@agent') &&
+          !contains(github.event.comment.body || github.event.review.body, '/fix') &&
+          (
+            (github.event.comment.author_association || github.event.review.author_association) == 'OWNER' ||
+            (github.event.comment.author_association || github.event.review.author_association) == 'MEMBER' ||
+            (github.event.comment.author_association || github.event.review.author_association) == 'COLLABORATOR'
+          )
         )
       )
     steps:

--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -31,18 +31,22 @@ jobs:
   fix:
     runs-on: macos-latest
     if: >-
+      github.actor == 'naqvitalha' &&
+      github.triggering_actor == 'naqvitalha' &&
       (
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'agent-fix' &&
-        github.event.sender.type != 'Bot'
-      ) || (
-        github.event.action == 'created' &&
-        contains(github.event.comment.body, '/fix') &&
-        !github.event.issue.pull_request &&
         (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'agent-fix' &&
+          github.event.sender.type != 'Bot'
+        ) || (
+          github.event.action == 'created' &&
+          contains(github.event.comment.body, '/fix') &&
+          !github.event.issue.pull_request &&
+          (
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          )
         )
       )
     steps:

--- a/.github/workflows/agent-triage.yml
+++ b/.github/workflows/agent-triage.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: >-
+      github.actor == 'naqvitalha' &&
+      github.triggering_actor == 'naqvitalha' &&
       github.event.label.name == 'agent-triage' &&
       github.event.sender.type != 'Bot'
     steps:


### PR DESCRIPTION
## Description

Temporarily restrict the FlashList agent workflows to a single GitHub actor while the incident review is ongoing. The job-level gates now require both `github.actor` and `github.triggering_actor` to be `naqvitalha`, preventing other users from triggering or rerunning these jobs.

## Reviewers' hat-rack :tophat:

Focus on the job-level `if` expressions and whether the temporary actor gate should apply to all agent trigger paths, including labels, comments, reviews, and manual dispatch.

## Screenshots or videos

Not applicable.

## Test plan

- [x] Parsed the updated workflow YAML files with Ruby YAML
- [x] Ran `git diff --check`
