### PR TITLE
fix(web): stop scrollbar-oscillation relayout loop in LinearLayoutManager

### DIFF
--- a/src/__tests__/LinearLayoutManager.test.ts
+++ b/src/__tests__/LinearLayoutManager.test.ts
@@ -288,4 +288,94 @@ describe("LinearLayoutManager", () => {
       expect(getAllLayouts(manager).length).toBe(3);
     });
   });
+
+  describe("Web scrollbar oscillation (issue #2334)", () => {
+    // On web with classic (non-overlay) scrollbars, the scrollbar's own width
+    // (~15-17px) feeds back into boundedSize: showing the scrollbar narrows the
+    // measured width, which can make content fit and hide the scrollbar, which
+    // widens the measurement again, re-triggering the scrollbar... forever.
+    // updateLayoutParams must detect this A/B/A bounce and stop recomputing.
+    const noScrollbarWidth = 400;
+    const scrollbarWidth = 383; // 400 - 17px classic scrollbar
+
+    it("locks boundedSize and stops recomputing once a scrollbar-width oscillation is detected", () => {
+      const manager = createPopulatedLayoutManager(
+        LayoutManagerType.LINEAR,
+        3,
+        defaultParams,
+        100,
+        100
+      );
+      const recomputeSpy = jest.spyOn(manager, "recomputeLayouts");
+
+      const oscillation = [
+        scrollbarWidth,
+        noScrollbarWidth,
+        scrollbarWidth,
+        noScrollbarWidth,
+        scrollbarWidth,
+        noScrollbarWidth,
+        scrollbarWidth,
+        noScrollbarWidth,
+        scrollbarWidth,
+        noScrollbarWidth,
+      ];
+
+      for (const width of oscillation) {
+        manager.updateLayoutParams(
+          createLayoutParams({
+            ...defaultParams,
+            windowSize: { width, height: 900 },
+          })
+        );
+      }
+
+      // Without hysteresis every alternation triggers a fresh recompute (10
+      // calls -> 10 recomputes), which is exactly the "Maximum update depth
+      // exceeded" feedback loop from the report. Detection should lock the
+      // layout after the first A/B/A bounce and stop recomputing further.
+      expect(recomputeSpy.mock.calls.length).toBeLessThanOrEqual(3);
+
+      const callsAfterFirstBatch = recomputeSpy.mock.calls.length;
+
+      // The scrollbar keeps flickering indefinitely - this must never grow
+      // the recompute count again (i.e. the layout has converged/locked).
+      for (let i = 0; i < 20; i++) {
+        manager.updateLayoutParams(
+          createLayoutParams({
+            ...defaultParams,
+            windowSize: {
+              width: i % 2 === 0 ? scrollbarWidth : noScrollbarWidth,
+              height: 900,
+            },
+          })
+        );
+      }
+
+      expect(recomputeSpy.mock.calls.length).toBe(callsAfterFirstBatch);
+    });
+
+    it("still recomputes for a genuine width change larger than the scrollbar threshold", () => {
+      const manager = createPopulatedLayoutManager(
+        LayoutManagerType.LINEAR,
+        3,
+        defaultParams,
+        100,
+        100
+      );
+      const recomputeSpy = jest.spyOn(manager, "recomputeLayouts");
+
+      // A real resize (150px), not scrollbar noise - must still recompute.
+      manager.updateLayoutParams(
+        createLayoutParams({
+          ...defaultParams,
+          windowSize: { width: 250, height: 900 },
+        })
+      );
+
+      expect(recomputeSpy.mock.calls.length).toBe(1);
+      const layouts = getAllLayouts(manager);
+      expect(layouts[0].width).toBe(250);
+    });
+  });
 });

--- a/src/recyclerview/layout-managers/LinearLayoutManager.ts
+++ b/src/recyclerview/layout-managers/LinearLayoutManager.ts
@@ -21,6 +21,26 @@ export class RVLinearLayoutManagerImpl extends RVLayoutManager {
   /** Height of the tallest item */
   private tallestItemHeight = 0;
 
+  /**
+   * Rolling history (most recent last) of raw incoming bounded-size values,
+   * used to detect a web scrollbar show/hide feedback loop before it is
+   * "locked". Cleared once a real (non-oscillating) resize is observed.
+   */
+  private boundedSizeHistory: number[] = [];
+  /**
+   * When set, boundedSize is pinned to this value because an oscillation was
+   * detected. Incoming sizes within SCROLLBAR_OSCILLATION_THRESHOLD of this
+   * value are treated as scrollbar noise and ignored; a larger delta is
+   * treated as a genuine resize and clears the lock.
+   */
+  private lockedBoundedSize?: number;
+  /**
+   * Max cross-axis delta (px) treated as scrollbar-induced noise rather than
+   * a real resize. Classic (non-overlay) scrollbars are typically 15-17px
+   * wide; 20px gives a small margin without masking real resizes.
+   */
+  private static readonly SCROLLBAR_OSCILLATION_THRESHOLD = 20;
+
   constructor(params: LayoutParams, previousLayoutManager?: RVLayoutManager) {
     super(params, previousLayoutManager);
     this.boundedSize = this.horizontal
@@ -31,15 +51,32 @@ export class RVLinearLayoutManagerImpl extends RVLayoutManager {
 
   /**
    * Updates layout parameters and triggers recomputation if necessary.
+   *
+   * On web with classic (non-overlay) scrollbars, showing/hiding the
+   * scrollbar changes the measured cross-axis size by its width, which can
+   * flip content between "fits" and "overflows" and re-trigger the
+   * scrollbar - an infinite show/hide/relayout loop (issue #2334). To break
+   * that loop we detect an A/B/A bounce within a small threshold and lock
+   * boundedSize until a genuinely larger change arrives.
    * @param params New layout parameters
    */
   updateLayoutParams(params: LayoutParams): void {
     const prevHorizontal = this.horizontal;
     super.updateLayoutParams(params);
     const oldBoundedSize = this.boundedSize;
-    this.boundedSize = this.horizontal
+    const incomingBoundedSize = this.horizontal
       ? params.windowSize.height
       : params.windowSize.width;
+
+    if (prevHorizontal !== this.horizontal) {
+      // Axis changed: bounded size now means something different, so any
+      // in-progress oscillation tracking no longer applies.
+      this.lockedBoundedSize = undefined;
+      this.boundedSizeHistory = [];
+    }
+
+    this.boundedSize = this.resolveBoundedSize(incomingBoundedSize);
+
     if (
       oldBoundedSize !== this.boundedSize ||
       prevHorizontal !== this.horizontal
@@ -50,6 +87,44 @@ export class RVLinearLayoutManagerImpl extends RVLayoutManager {
         this.requiresRepaint = true;
       }
     }
+  }
+
+  /**
+   * Resolves the bounded size to use for this update, applying scrollbar
+   * oscillation detection/locking. See updateLayoutParams for context.
+   * @param incomingBoundedSize Raw bounded size derived from this update's params
+   */
+  private resolveBoundedSize(incomingBoundedSize: number): number {
+    const threshold = RVLinearLayoutManagerImpl.SCROLLBAR_OSCILLATION_THRESHOLD;
+
+    if (this.lockedBoundedSize !== undefined) {
+      if (Math.abs(incomingBoundedSize - this.lockedBoundedSize) <= threshold) {
+        // Scrollbar noise while locked - ignore, stay pinned.
+        return this.lockedBoundedSize;
+      }
+      // Large enough to be a genuine resize - unlock and re-baseline.
+      this.lockedBoundedSize = undefined;
+      this.boundedSizeHistory = [];
+    }
+
+    this.boundedSizeHistory.push(incomingBoundedSize);
+    if (this.boundedSizeHistory.length > 3) {
+      this.boundedSizeHistory.shift();
+    }
+
+    const [first, second, third] = this.boundedSizeHistory;
+    const isOscillating =
+      this.boundedSizeHistory.length === 3 &&
+      first === third &&
+      first !== second &&
+      Math.abs(first - second) <= threshold;
+
+    if (isOscillating) {
+      this.lockedBoundedSize = first;
+      return first;
+    }
+
+    return incomingBoundedSize;
   }
 
   /**


### PR DESCRIPTION
On web with classic (non-overlay) scrollbars, borderline-overflow content makes the scrollbar toggle on and off every frame, which loops relayout forever and crashes with "Maximum update depth exceeded".

`updateLayoutParams()` recomputed on any `boundedSize` change with no hysteresis, so a ~17px scrollbar-width delta alternated indefinitely. This adds A/B/A oscillation detection: when the cross-axis size alternates between two values within a scrollbar-width threshold (20px), it locks to the narrower one and treats further sub-threshold changes as noise. A real resize past the threshold unlocks and re-baselines; an axis flip clears the lock.

The test is a pure layout-manager unit test that feeds an oscillating width sequence and asserts convergence instead of unbounded recompute. It fails without the fix (10 unbounded recomputes) and passes with it. Layout-manager and grid/masonry suites green, tsc and lint clean.

Closes #2334
