### PR TITLE
fix(recyclerview): prevent orphaned pending child layouts

### DIFF
--- a/src/__tests__/RecyclerView.test.tsx
+++ b/src/__tests__/RecyclerView.test.tsx
@@ -4,6 +4,8 @@ import "@quilted/react-testing/matchers";
 import { render } from "@quilted/react-testing";
 
 import { FlashListRef } from "../FlashListRef";
+import { RecyclerViewContextProvider } from "../recyclerview/RecyclerViewContextProvider";
+import type { RecyclerViewContext } from "../recyclerview/RecyclerViewContextProvider";
 import { FlashList } from "..";
 
 // Mock measureLayout to return fixed dimensions
@@ -75,6 +77,83 @@ describe("RecyclerView", () => {
 
       expect(result).toContainReactComponent(Text, { children: 0 });
       expect(result).not.toContainReactComponent(Text, { children: 11 });
+    });
+  });
+
+  describe("nested layout coordination", () => {
+    const createParentContext = (): RecyclerViewContext<unknown> => ({
+      layout: jest.fn(),
+      getRef: jest.fn(() => null),
+      getParentRef: jest.fn(() => null),
+      getScrollViewRef: jest.fn(() => null),
+      getParentScrollViewRef: jest.fn(() => null),
+      markChildLayoutAsPending: jest.fn(),
+      unmarkChildLayoutAsPending: jest.fn(),
+    });
+
+    it("does not mark a child layout as pending when rendering is discarded", () => {
+      const parentContext = createParentContext();
+      const consoleError = jest.spyOn(console, "error").mockImplementation();
+      class ErrorBoundary extends React.Component<
+        React.PropsWithChildren,
+        { hasError: boolean }
+      > {
+        state: { hasError: boolean } = { hasError: false };
+
+        static getDerivedStateFromError() {
+          return { hasError: true };
+        }
+
+        render() {
+          return this.state.hasError ? null : this.props.children;
+        }
+      }
+
+      render(
+        <RecyclerViewContextProvider value={parentContext}>
+          <ErrorBoundary>
+            <FlashList
+              horizontal
+              stickyHeaderIndices={[0]}
+              data={[0]}
+              renderItem={({ item }) => <Text>{item}</Text>}
+              overrideProps={{ initialDrawBatchSize: 1 }}
+              drawDistance={0}
+            />
+          </ErrorBoundary>
+        </RecyclerViewContextProvider>
+      );
+
+      expect(parentContext.markChildLayoutAsPending).not.toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    it("unmarks a pending child layout when it unmounts", () => {
+      const parentContext = createParentContext();
+      const NestedList = ({ show }: { show: boolean }) => (
+        <View>
+          {show ? (
+            <RecyclerViewContextProvider value={parentContext}>
+              <FlashList
+                data={[0]}
+                renderItem={({ item }) => <Text>{item}</Text>}
+                overrideProps={{ initialDrawBatchSize: 1 }}
+                drawDistance={0}
+              />
+            </RecyclerViewContextProvider>
+          ) : null}
+        </View>
+      );
+      const result = render(<NestedList show />);
+      const markedId = (parentContext.markChildLayoutAsPending as jest.Mock)
+        .mock.calls[0][0];
+
+      (parentContext.unmarkChildLayoutAsPending as jest.Mock).mockClear();
+      result.setProps({ show: false });
+
+      expect(parentContext.unmarkChildLayoutAsPending).toHaveBeenCalledWith(
+        markedId
+      );
     });
   });
 

--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -412,12 +412,28 @@ const RecyclerViewComponent = <T,>(
     renderStickyHeaderBackdrop,
   } = useSecondaryProps(props);
 
-  if (
-    !recyclerViewManager.getIsFirstLayoutComplete() &&
-    recyclerViewManager.getDataLength() > 0
-  ) {
-    parentRecyclerViewContext?.markChildLayoutAsPending(recyclerViewId);
-  }
+  // Mark only committed children so interrupted renders cannot leave orphaned IDs.
+  useLayoutEffect(() => {
+    const shouldSkipPendingMark =
+      horizontal &&
+      recyclerViewManager.hasLayout() &&
+      recyclerViewManager.getWindowSize().height > 0;
+
+    if (
+      !recyclerViewManager.getIsFirstLayoutComplete() &&
+      recyclerViewManager.getDataLength() > 0 &&
+      !shouldSkipPendingMark
+    ) {
+      parentRecyclerViewContext?.markChildLayoutAsPending(recyclerViewId);
+    }
+  });
+
+  // Release the parent if this child unmounts before its first layout commits.
+  useLayoutEffect(() => {
+    return () => {
+      parentRecyclerViewContext?.unmarkChildLayoutAsPending(recyclerViewId);
+    };
+  }, [parentRecyclerViewContext, recyclerViewId]);
 
   // Render sticky headers if configured
   const stickyHeaders = useMemo(() => {


### PR DESCRIPTION
## Description

Fixes #2319

Move nested `RecyclerView` pending-layout registration from the render phase to a layout effect. This prevents interrupted or otherwise discarded renders from adding an ID to the parent list's `pendingChildIds` set without a matching commit that can remove it.

Add an unmount cleanup that releases the child ID when a nested list is removed before its first layout completes. The existing horizontal-list early-unmark behavior remains intact by skipping the commit-phase mark once a horizontal child already has a measured height.

Without these changes, an orphaned ID can make the parent list's relayout effect return early on every later commit, leaving item offsets and content size permanently stale until the parent remounts.

## Reviewers’ hat-rack :tophat:

- [ ] Confirm commit-phase registration preserves first-layout coordination for nested lists.
- [ ] Confirm horizontal children are not re-marked after the existing early-unmark path.
- [ ] Confirm unmount cleanup is safe when the child already completed and unmarked its first layout.

## Screenshots or videos (if needed)

Not applicable; this changes layout lifecycle coordination without a deterministic visual state.

## Testing

- Added regression coverage for a render that throws before commit and must not mark its parent.
- Added regression coverage for unmounting a pending nested list and releasing its ID.
- `yarn test --runInBand` (14 suites, 189 tests)
- `yarn lint`
- `yarn type-check`
- `yarn build`
- Prettier check for the changed files
