### PR TITLE
fix: replace seeded values correctly in capacity-one average windows

### DIFF
--- a/src/utils/AverageWindow.ts
+++ b/src/utils/AverageWindow.ts
@@ -10,7 +10,7 @@ export class AverageWindow {
     this.inputValues = new Array<number>(Math.max(1, size));
     this.currentAverage = startValue ?? 0;
     this.currentCount = startValue === undefined ? 0 : 1;
-    this.nextIndex = this.currentCount;
+    this.nextIndex = this.currentCount % this.inputValues.length;
     this.inputValues[0] = startValue;
   }
 


### PR DESCRIPTION
## Fixes

Keep the next insertion index inside the ring when its initial value already fills a one-element window. This prevents extending the backing array and averaging a stale seed.

## Compatibility / observable changes

No public API change. A capacity-one seeded average now reports the newest sample rather than averaging it with the seed.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - average capacity-one seed is replaced, not extended
  - average zero capacity is clamped to one with seed
  - average larger seeded ring remains stable
  - average unseeded capacity-one ring remains stable
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
