### PR TITLE
fix: preserve continuous viewability dwell time and release timers

### DIFF
--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -282,7 +282,8 @@ export class RecyclerViewManager<T> {
 
   computeItemViewability() {
     // Using higher buffer for masonry to avoid missing items
-    this.itemViewabilityManager.shouldListenToVisibleIndices &&
+    this.hasLayout() &&
+      this.itemViewabilityManager.shouldListenToVisibleIndices &&
       this.itemViewabilityManager.updateViewableItems(
         this.propsRef.masonry
           ? this.engagedIndicesTracker.getEngagedIndices().toArray()

--- a/src/recyclerview/viewability/ViewabilityHelper.ts
+++ b/src/recyclerview/viewability/ViewabilityHelper.ts
@@ -26,6 +26,8 @@ class ViewabilityHelper {
   ) => void;
 
   private timers: Set<NodeJS.Timeout> = new Set();
+  private visibilityGenerations = new Map<number, number>();
+  private updateGeneration = 0;
 
   constructor(
     viewabilityConfig: ViewabilityConfig | null | undefined,
@@ -42,6 +44,9 @@ class ViewabilityHelper {
   public dispose() {
     // Clean up on dismount
     this.timers.forEach(clearTimeout);
+    this.timers.clear();
+    this.viewableIndices = [];
+    this.visibilityGenerations.clear();
   }
 
   public updateViewableItems(
@@ -81,13 +86,46 @@ class ViewabilityHelper {
         getLayout
       )
     );
+    if (
+      newViewableIndices.length === this.viewableIndices.length &&
+      newViewableIndices.every(
+        (index, position) => index === this.viewableIndices[position]
+      ) &&
+      (this.timers.size > 0 ||
+        (newViewableIndices.length ===
+          this.lastReportedViewableIndices.length &&
+          newViewableIndices.every(
+            (index, position) =>
+              index === this.lastReportedViewableIndices[position]
+          )))
+    ) {
+      return;
+    }
+    const generation = ++this.updateGeneration;
+    const currentIndices = new Set(newViewableIndices);
+    for (const index of this.visibilityGenerations.keys()) {
+      if (!currentIndices.has(index)) {
+        this.visibilityGenerations.delete(index);
+      }
+    }
+    for (const index of newViewableIndices) {
+      if (!this.visibilityGenerations.has(index)) {
+        this.visibilityGenerations.set(index, generation);
+      }
+    }
     this.viewableIndices = newViewableIndices;
     const minimumViewTime = this.viewabilityConfig?.minimumViewTime ?? 250;
     // Setting default to 250. Default of 0 can impact performance when user scrolls fast.
     if (minimumViewTime > 0) {
       const timeoutId = setTimeout(() => {
         this.timers.delete(timeoutId);
-        this.checkViewableIndicesChanges(newViewableIndices);
+        // A returning item must complete a new uninterrupted visibility interval.
+        this.checkViewableIndicesChanges(
+          newViewableIndices.filter((index) => {
+            const visibleSince = this.visibilityGenerations.get(index);
+            return visibleSince !== undefined && visibleSince <= generation;
+          })
+        );
       }, minimumViewTime);
       this.timers.add(timeoutId);
     } else {
@@ -97,14 +135,17 @@ class ViewabilityHelper {
 
   public checkViewableIndicesChanges(newViewableIndices: number[]) {
     // Check if all viewable indices are still available (applicable if minimumViewTime > 0)
+    const currentIndices = new Set(this.viewableIndices);
+    const lastReportedIndices = new Set(this.lastReportedViewableIndices);
     const currentlyNewViewableIndices = newViewableIndices.filter((index) =>
-      this.viewableIndices.includes(index)
+      currentIndices.has(index)
     );
+    const newIndices = new Set(currentlyNewViewableIndices);
     const newlyVisibleItems = currentlyNewViewableIndices.filter(
-      (index) => !this.lastReportedViewableIndices.includes(index)
+      (index) => !lastReportedIndices.has(index)
     );
     const newlyNonvisibleItems = this.lastReportedViewableIndices.filter(
-      (index) => !currentlyNewViewableIndices.includes(index)
+      (index) => !newIndices.has(index)
     );
 
     if (newlyVisibleItems.length > 0 || newlyNonvisibleItems.length > 0) {
@@ -118,6 +159,7 @@ class ViewabilityHelper {
   }
 
   public clearLastReportedViewableIndices() {
+    this.dispose();
     this.lastReportedViewableIndices = [];
   }
 
@@ -140,13 +182,12 @@ class ViewabilityHelper {
     const pixelsVisible =
       Math.min(itemTop + itemSize, listMainSize) - Math.max(itemTop, 0);
 
+    if (pixelsVisible <= 0) {
+      return false;
+    }
     // Always consider item fully viewable if it is fully visible, regardless of the `viewAreaCoveragePercentThreshold`
     if (pixelsVisible === itemSize) {
       return true;
-    }
-    // Skip checking item if it's not visible at all
-    if (pixelsVisible === 0) {
-      return false;
     }
     const viewAreaMode =
       viewAreaCoveragePercentThreshold !== null &&

--- a/src/recyclerview/viewability/ViewabilityManager.ts
+++ b/src/recyclerview/viewability/ViewabilityManager.ts
@@ -71,10 +71,10 @@ export default class ViewabilityManager<T> {
   };
 
   public updateViewableItems = (newViewableIndices?: number[]) => {
-    const listSize = this.rvManager.getWindowSize();
-    if (listSize === undefined || !this.shouldListenToVisibleIndices) {
+    if (!this.shouldListenToVisibleIndices || !this.rvManager.hasLayout()) {
       return;
     }
+    const listSize = this.rvManager.getWindowSize();
     const scrollOffset =
       (this.rvManager.getAbsoluteLastScrollOffset() ?? 0) -
       this.rvManager.firstItemOffset;


### PR DESCRIPTION
## Fixes

Track uninterrupted visibility generations, avoid redundant identical-set timers, release fired/disposed handles, invalidate obsolete recomputation timers, exclude zero-size/offscreen items and permit recordInteraction before the first layout. Preserve the configured removal delay.

## Compatibility / observable changes

No signature change. An item that leaves and re-enters must now satisfy minimumViewTime again; zero-size items are no longer reported as visible. Early recordInteraction calls no longer throw.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - viewability waits for minimum view time
  - viewability restarts dwell time after leaving and returning
  - viewability does not delay an unchanged visible set
  - viewability avoids redundant unchanged-set timers
  - viewability never reports zero-size items
  - viewability disposal cancels pending callbacks and releases handles
  - viewability can resume after strict-mode disposal
  - viewability reports removal after disposal and empty resume
  - viewability recompute clears stale dwell timers
  - viewability delays removal by the configured minimum time
  - viewability ignores stale pending membership after removal
  - viewability interaction before layout with listener false
  - viewability interaction before layout with listener true
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
