### PR TITLE
fix: forward extraData to the documented getItemType callback

### DIFF
--- a/src/__tests__/RecyclerViewManager.test.ts
+++ b/src/__tests__/RecyclerViewManager.test.ts
@@ -71,4 +71,24 @@ describe("RecyclerViewManager", () => {
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
   });
+
+  it("forwards extraData to getItemType", () => {
+    const data = [{ id: 1 }];
+    const extraData = { itemType: "featured" };
+    const getItemType = jest.fn(
+      (item: typeof data[number], index: number, currentExtraData: any) =>
+        currentExtraData.itemType
+    );
+    const manager = new RecyclerViewManager({
+      data,
+      extraData,
+      getItemType,
+      renderItem: jest.fn(),
+    });
+
+    manager.updateLayoutParams({ width: 100, height: 100 }, 0);
+    manager.processDataUpdate();
+
+    expect(getItemType).toHaveBeenCalledWith(data[0], 0, extraData);
+  });
 });

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -441,8 +441,11 @@ export class RecyclerViewManager<T> {
 
   private getItemType(index: number): string {
     return (
-      this.propsRef.getItemType?.(this.propsRef.data![index], index) ??
-      "default"
+      this.propsRef.getItemType?.(
+        this.propsRef.data![index],
+        index,
+        this.propsRef.extraData
+      ) ?? "default"
     ).toString();
   }
 


### PR DESCRIPTION
## Fix

- pass the current `extraData` as the documented third argument of `getItemType`
- add a focused regression that exercises the real layout-manager call path

## Problem

`FlashListProps` documents `getItemType(item, index, extraData)`, but `RecyclerViewManager` supplied only the first two arguments. Callbacks using the documented third argument therefore received `undefined` during layout and recycling.

## Compatibility / observable changes

No signature change. Callbacks now receive their documented third argument. This PR does not claim that changing only `extraData` reassigns every existing recycled cell; that is a separate behavior and is intentionally excluded.

## Verification

- regression fails on untouched `main` and passes with this fix
- full Jest suite: 14 suites, 188 tests passed
- library TypeScript check passed
- changed-file ESLint and `git diff --check` passed
- no dependency, lockfile, native SDK, or Songstats application change

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and focused regression.
- [ ] Run the existing test/type/lint commands on a supported environment.