### PR TITLE
fix: bound benchmark work and clean up cancelled or failed runs

### DIFF
--- a/documentation/docs/guides/list-profiling.md
+++ b/documentation/docs/guides/list-profiling.md
@@ -60,6 +60,10 @@ The `useBenchmark` hook accepts an optional `BenchmarkParams` object:
 
 ## Understanding Results
 
+Both benchmark hooks ignore duplicate starts while a run is active and cancel automatic or manual runs on unmount. Cancelled unmounted runs do not invoke the result callback. An explicit `startDelayInMs: 0` starts without the default delay.
+
+Use a positive finite `speedMultiplier` and a positive integer `repeatCount`. Invalid options or failed scrolling produce a result with `interrupted: true` and an explanation in `suggestions`; the running state and FPS monitor are cleaned up so another run can start. Check `interrupted` before treating the FPS data as a completed benchmark.
+
 The benchmark returns a `BenchmarkResult` object containing:
 
 ```typescript

--- a/src/benchmark/AutoScrollHelper.ts
+++ b/src/benchmark/AutoScrollHelper.ts
@@ -18,7 +18,19 @@ export function autoScroll(
   speedMultiplier = 1,
   cancellable: Cancellable = new Cancellable()
 ): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    if (cancellable.isCancelled()) {
+      resolve(false);
+      return;
+    }
+    if (
+      ![fromX, fromY, toX, toY, speedMultiplier].every(Number.isFinite) ||
+      speedMultiplier <= 0
+    ) {
+      throw new Error(
+        "Scroll coordinates must be finite and speed must be positive."
+      );
+    }
     scroll(fromX, fromY, false);
     // Very fast scrolls on Android/iOS typically move content 7px every millisecond.
     const incrementPerMs = 7 * speedMultiplier;
@@ -42,7 +54,12 @@ export function autoScroll(
         const distanceToCover = incrementPerMs * timeElapsed;
         startX += distanceToCover * directionMultiplierX;
         startY += distanceToCover * directionMultiplierY;
-        scroll(comparatorX(toX, startX), comparatorY(toY, startY), false);
+        try {
+          scroll(comparatorX(toX, startX), comparatorY(toY, startY), false);
+        } catch (error) {
+          reject(error);
+          return;
+        }
         startTime = currentTime;
         if (
           comparatorX(toX, startX) !== toX ||

--- a/src/benchmark/useBenchmark.ts
+++ b/src/benchmark/useBenchmark.ts
@@ -1,7 +1,14 @@
-import React, { useEffect, useState, useCallback, useRef } from "react";
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useCallback,
+  useRef,
+} from "react";
 
 import { FlashListRef } from "../FlashListRef";
 import { ErrorMessages } from "../errors/ErrorMessages";
+import { useUnmountFlag } from "../recyclerview/hooks/useUnmountFlag";
 
 import { autoScroll, Cancellable } from "./AutoScrollHelper";
 import { JSFPSMonitor, JSFPSResult } from "./JSFPSMonitor";
@@ -50,82 +57,107 @@ export function useBenchmark(
   callback: (benchmarkResult: BenchmarkResult) => void,
   params: BenchmarkParams = {}
 ) {
-  const [isBenchmarkRunning, setIsBenchmarkRunning] = useState(false);
-  const cancellableRef = useRef<Cancellable | null>(null);
-
-  const startBenchmark = useCallback(() => {
-    if (isBenchmarkRunning) {
-      return;
-    }
-
-    const cancellable = new Cancellable();
-    cancellableRef.current = cancellable;
-    const suggestions: string[] = [];
-
-    if (flashListRef.current) {
-      if (!(Number(flashListRef.current.props.data?.length) > 0)) {
-        throw new Error(ErrorMessages.dataEmptyCannotRunBenchmark);
+  return useBenchmarkRunner(
+    async (cancellable) => {
+      const suggestions: string[] = [];
+      if (flashListRef.current) {
+        if (!(Number(flashListRef.current.props.data?.length) > 0)) {
+          throw new Error(ErrorMessages.dataEmptyCannotRunBenchmark);
+        }
       }
-    }
-
-    setIsBenchmarkRunning(true);
-
-    const runBenchmark = async () => {
-      const jsFPSMonitor = new JSFPSMonitor();
-      jsFPSMonitor.startTracking();
-      for (let i = 0; i < (params.repeatCount || 1); i++) {
+      for (let i = 0; i < (params.repeatCount ?? 1); i++) {
+        if (cancellable.isCancelled()) break;
         await runScrollBenchmark(
           flashListRef,
           cancellable,
-          params.speedMultiplier || 1
-        );
-      }
-      const jsProfilerResponse = jsFPSMonitor.stopAndGetData();
-      if (jsProfilerResponse.averageFPS < 35) {
-        suggestions.push(
-          `Your average JS FPS is low. This can indicate that your components are doing too much work. Try to optimize your components and reduce re-renders if any`
+          params.speedMultiplier ?? 1
         );
       }
       computeSuggestions(flashListRef, suggestions);
-      const result: BenchmarkResult = generateResult(
-        jsProfilerResponse,
-        suggestions,
-        cancellable
-      );
-      if (!cancellable.isCancelled()) {
-        result.formattedString = getFormattedString(result);
-      }
-      callback(result);
-      setIsBenchmarkRunning(false);
-    };
-
-    runBenchmark();
-  }, [
+      return suggestions;
+    },
     callback,
-    flashListRef,
-    isBenchmarkRunning,
-    params.repeatCount,
-    params.speedMultiplier,
-  ]);
+    params,
+    true
+  );
+}
+
+/** Shared lifecycle for FlashList and FlatList benchmark runs. */
+export function useBenchmarkRunner(
+  run: (cancellable: Cancellable) => Promise<string[]>,
+  callback: (benchmarkResult: BenchmarkResult) => void,
+  params: BenchmarkParams,
+  suggestJSOptimization = false
+) {
+  const [isBenchmarkRunning, setIsBenchmarkRunning] = useState(false);
+  const isUnmounted = useUnmountFlag();
+  const activeRun = useRef<{
+    cancellable: Cancellable;
+    monitor: JSFPSMonitor;
+  } | null>(null);
+  const latest = useRef({ run, callback, params, suggestJSOptimization });
+  useLayoutEffect(() => {
+    latest.current = { run, callback, params, suggestJSOptimization };
+  });
+  const [initialOptions] = useState(() => ({
+    startManually: params.startManually,
+    startDelayInMs: params.startDelayInMs ?? 3000,
+  }));
+
+  const startBenchmark = useCallback(() => {
+    if (activeRun.current || isUnmounted.current) return;
+    const request = {
+      cancellable: new Cancellable(),
+      monitor: new JSFPSMonitor(),
+    };
+    activeRun.current = request;
+    setIsBenchmarkRunning(true);
+    const options = latest.current;
+    const runBenchmark = async () => {
+      let suggestions: string[] = [];
+      let interrupted = false;
+      let js: JSFPSResult;
+      try {
+        const repeatCount = options.params.repeatCount ?? 1;
+        if (!Number.isInteger(repeatCount) || repeatCount < 1) {
+          throw new Error("repeatCount must be a positive integer.");
+        }
+        request.monitor.startTracking();
+        suggestions = await options.run(request.cancellable);
+      } catch (error) {
+        interrupted = true;
+        suggestions.push(`Benchmark failed: ${String(error)}`);
+      } finally {
+        js = request.monitor.stopAndGetData();
+        if (activeRun.current === request) {
+          activeRun.current = null;
+          if (!isUnmounted.current) setIsBenchmarkRunning(false);
+        }
+      }
+      if (isUnmounted.current || request.cancellable.isCancelled()) return;
+      if (!interrupted && options.suggestJSOptimization && js.averageFPS < 35) {
+        suggestions.unshift(
+          "Your average JS FPS is low. This can indicate that your components are doing too much work. Try to optimize your components and reduce re-renders if any"
+        );
+      }
+      const result: BenchmarkResult = { js, suggestions, interrupted };
+      result.formattedString = getFormattedString(result);
+      latest.current.callback(result);
+    };
+    return runBenchmark();
+  }, [isUnmounted]);
 
   useEffect(() => {
-    if (params.startManually) {
-      return;
-    }
-
-    const cancelTimeout = setTimeout(() => {
-      startBenchmark();
-    }, params.startDelayInMs || 3000);
-
+    const cancelTimeout = initialOptions.startManually
+      ? undefined
+      : setTimeout(startBenchmark, initialOptions.startDelayInMs);
     return () => {
       clearTimeout(cancelTimeout);
-      if (cancellableRef.current) {
-        cancellableRef.current.cancel();
-      }
+      activeRun.current?.cancellable.cancel();
+      activeRun.current?.monitor.stopAndGetData();
+      activeRun.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+  }, [initialOptions, startBenchmark]);
   return { startBenchmark, isBenchmarkRunning } as const;
 }
 
@@ -141,18 +173,6 @@ export function getFormattedString(res: BenchmarkResult) {
         : ``
     }`
   );
-}
-
-function generateResult(
-  jsProfilerResponse: JSFPSResult,
-  suggestions: string[],
-  cancellable: Cancellable
-) {
-  return {
-    js: jsProfilerResponse,
-    suggestions,
-    interrupted: cancellable.isCancelled(),
-  };
 }
 
 /**
@@ -172,8 +192,12 @@ async function runScrollBenchmark(
 
       const fromX = 0;
       const fromY = 0;
-      const toX = rvContentSize.width - rvSize.width;
-      const toY = rvContentSize.height - rvSize.height;
+      const toX = horizontal
+        ? Math.max(0, rvContentSize.width - rvSize.width)
+        : 0;
+      const toY = horizontal
+        ? 0
+        : Math.max(0, rvContentSize.height - rvSize.height);
 
       const scrollNow = (x: number, y: number) => {
         flashListRef.current?.scrollToOffset({
@@ -209,7 +233,7 @@ function computeSuggestions(
   suggestions: string[]
 ) {
   if (flashListRef.current) {
-    if (flashListRef.current.props.data!!.length < 200) {
+    if ((flashListRef.current.props.data?.length ?? 0) < 200) {
       suggestions.push(
         `Data count is low. Try to increase it to a large number (e.g 200) using the 'useDataMultiplier' hook.`
       );

--- a/src/benchmark/useFlatListBenchmark.ts
+++ b/src/benchmark/useFlatListBenchmark.ts
@@ -1,14 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import { FlatList } from "react-native";
 
 import { ErrorMessages } from "../errors/ErrorMessages";
 
 import { autoScroll, Cancellable } from "./AutoScrollHelper";
-import { JSFPSMonitor } from "./JSFPSMonitor";
 import {
   BenchmarkParams,
   BenchmarkResult,
-  getFormattedString,
+  useBenchmarkRunner,
 } from "./useBenchmark";
 
 export interface FlatListBenchmarkParams extends BenchmarkParams {
@@ -25,75 +23,28 @@ export function useFlatListBenchmark(
   callback: (benchmarkResult: BenchmarkResult) => void,
   params: FlatListBenchmarkParams
 ) {
-  const [isBenchmarkRunning, setIsBenchmarkRunning] = useState(false);
-  const cancellableRef = useRef<Cancellable | null>(null);
-
-  const startBenchmark = useCallback(() => {
-    if (isBenchmarkRunning) {
-      return;
-    }
-    const cancellable = new Cancellable();
-    cancellableRef.current = cancellable;
-    if (flatListRef.current && flatListRef.current.props) {
-      if (!(Number(flatListRef.current.props.data?.length) > 0)) {
-        throw new Error(ErrorMessages.dataEmptyCannotRunBenchmark);
+  return useBenchmarkRunner(
+    async (cancellable) => {
+      if (flatListRef.current && flatListRef.current.props) {
+        if (!(Number(flatListRef.current.props.data?.length) > 0)) {
+          throw new Error(ErrorMessages.dataEmptyCannotRunBenchmark);
+        }
       }
-    }
 
-    setIsBenchmarkRunning(true);
-
-    const runBenchmark = async () => {
-      const jsFPSMonitor = new JSFPSMonitor();
-      jsFPSMonitor.startTracking();
-      for (let i = 0; i < (params.repeatCount || 1); i++) {
+      for (let i = 0; i < (params.repeatCount ?? 1); i++) {
+        if (cancellable.isCancelled()) break;
         await runScrollBenchmark(
           flatListRef,
           params.targetOffset,
           cancellable,
-          params.speedMultiplier || 1
+          params.speedMultiplier ?? 1
         );
       }
-      const jsProfilerResponse = jsFPSMonitor.stopAndGetData();
-      const result: BenchmarkResult = {
-        js: jsProfilerResponse,
-        suggestions: [],
-        interrupted: cancellable.isCancelled(),
-      };
-      if (!cancellable.isCancelled()) {
-        result.formattedString = getFormattedString(result);
-      }
-      callback(result);
-      setIsBenchmarkRunning(false);
-    };
-
-    runBenchmark();
-  }, [
+      return [];
+    },
     callback,
-    flatListRef,
-    isBenchmarkRunning,
-    params.repeatCount,
-    params.speedMultiplier,
-    params.targetOffset,
-  ]);
-
-  useEffect(() => {
-    if (params.startManually) {
-      return;
-    }
-
-    const cancelTimeout = setTimeout(() => {
-      startBenchmark();
-    }, params.startDelayInMs || 3000);
-
-    return () => {
-      clearTimeout(cancelTimeout);
-      if (cancellableRef.current) {
-        cancellableRef.current.cancel();
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  return { startBenchmark, isBenchmarkRunning };
+    params
+  );
 }
 
 /**


### PR DESCRIPTION
## Fixes

Share benchmark run ownership and cleanup; block same-tick duplicate starts, cancel manually started work on unmount, stop FPS monitoring on every terminal path, honor zero start delay, validate coordinates/speed/repeat counts and report interrupted failures. Clamp short-list target offsets and scroll only the active axis.

## Compatibility / observable changes

Observable change: invalid repeat counts/speeds and scroll failures produce an interrupted result with a diagnostic instead of leaving monitoring active or an unhandled internal failure. Unmounted runs do not invoke callbacks. Accepted manual starts return a completion promise (duplicate/late starts return undefined); callback exceptions still reject that promise.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - autoscroll completes normal forward and reverse paths
  - autoscroll does not scroll an already cancelled run
  - autoscroll converts frame callback failures to rejection
  - autoscroll rejects non-positive speed before scheduling
  - autoscroll rejects non-finite coordinates
  - benchmark FlashList manual runs cancel on unmount
  - benchmark FlashList guards duplicate synchronous starts
  - benchmark FlashList honors an explicit zero start delay
  - benchmark FlashList releases monitoring and reports scroll failure
  - benchmark FlatList manual runs cancel on unmount
  - benchmark FlatList guards duplicate synchronous starts
  - benchmark FlatList honors an explicit zero start delay
  - benchmark FlatList releases monitoring and reports scroll failure
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
