### PR TITLE
fix: refresh moved cell indices and use React state equality

### DIFF
--- a/src/recyclerview/ViewHolder.tsx
+++ b/src/recyclerview/ViewHolder.tsx
@@ -104,10 +104,7 @@ const ViewHolderInternal = <TItem,>(props: ViewHolderProps<TItem>) => {
 
   const children = useMemo(() => {
     return renderItem?.({ item, index, extraData, target }) ?? null;
-    // TODO: Test more thoroughly
-    // We don't really  to re-render the children when the index changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [item, extraData, target, renderItem]);
+  }, [item, index, extraData, target, renderItem]);
 
   const invertedTransformStyle = inverted
     ? getInvertedTransformStyle(horizontal)

--- a/src/recyclerview/hooks/useRecyclingState.ts
+++ b/src/recyclerview/hooks/useRecyclingState.ts
@@ -55,7 +55,7 @@ export function useRecyclingState<T>(
           : newValue;
 
       // Only update and trigger re-render if value has changed
-      if (nextState !== valueStore.current) {
+      if (!Object.is(nextState, valueStore.current)) {
         valueStore.current = nextState;
         setCounter((prev) => prev + 1, skipParentLayout);
       }


### PR DESCRIPTION
## Fixes

Include the current index in the renderItem memoization dependencies and use Object.is for state updates in useRecyclingState, matching React state equality.

## Compatibility / observable changes

No signature changes. A stable item moved to a different index now re-renders with that index. Setting NaN repeatedly no longer re-renders; updates between signed zero values now do.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - cell refreshes renderItem index when a stable item moves
  - recycling state treats repeated NaN as unchanged
  - recycling state preserves signed-zero changes
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
