### PR TITLE
fix: reject timeout and animation-frame work after unmount

### DIFF
--- a/src/recyclerview/hooks/useUnmountAwareCallbacks.ts
+++ b/src/recyclerview/hooks/useUnmountAwareCallbacks.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { useUnmountFlag } from "./useUnmountFlag";
+
 /**
  * Hook that provides a setTimeout which is aware of component unmount state.
  * Any timeouts created with this hook will be automatically cleared when the component unmounts.
  */
 export function useUnmountAwareTimeout() {
+  const isUnmounted = useUnmountFlag();
   // Store active timeout IDs in a Set for more efficient add/remove operations
   const [timeoutIds] = useState<Set<NodeJS.Timeout>>(() => new Set());
 
@@ -19,16 +22,21 @@ export function useUnmountAwareTimeout() {
   // Create a safe setTimeout that will be cleared on unmount
   const setTimeout = useCallback(
     (callback: () => void, delay: number): void => {
+      if (isUnmounted.current) {
+        return;
+      }
       const id = global.setTimeout(() => {
         // Remove this timeout ID from the tracking set
         timeoutIds.delete(id);
-        callback();
+        if (!isUnmounted.current) {
+          callback();
+        }
       }, delay);
 
       // Track this timeout ID
       timeoutIds.add(id);
     },
-    [timeoutIds]
+    [timeoutIds, isUnmounted]
   );
 
   return {
@@ -41,6 +49,7 @@ export function useUnmountAwareTimeout() {
  * Any animation frames requested with this hook will be automatically canceled when the component unmounts.
  */
 export function useUnmountAwareAnimationFrame() {
+  const isUnmounted = useUnmountFlag();
   // Store active animation frame request IDs in a Set for more efficient add/remove operations
   const [requestIds] = useState<Set<number>>(() => new Set());
 
@@ -55,16 +64,21 @@ export function useUnmountAwareAnimationFrame() {
   // Create a safe requestAnimationFrame that will be canceled on unmount
   const requestAnimationFrame = useCallback(
     (callback: FrameRequestCallback): void => {
+      if (isUnmounted.current) {
+        return;
+      }
       const id = global.requestAnimationFrame((timestamp) => {
         // Remove this request ID from the tracking set
         requestIds.delete(id);
-        callback(timestamp);
+        if (!isUnmounted.current) {
+          callback(timestamp);
+        }
       });
 
       // Track this request ID
       requestIds.add(id);
     },
-    [requestIds]
+    [requestIds, isUnmounted]
   );
 
   return {


### PR DESCRIPTION
## Fixes

Reuse the shared layout-effect unmount flag when scheduling and executing callbacks, while retaining cancellation and active-handle cleanup.

## Compatibility / observable changes

No public API change. Retained callback schedulers no longer schedule new work after their component has unmounted.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - unmount-aware Timeout rejects new work after unmount
  - unmount-aware Timeout clears existing work
  - unmount-aware AnimationFrame rejects new work after unmount
  - unmount-aware AnimationFrame clears existing work
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
