### PR TITLE
fix: reset stale sticky headers and avoid redundant offset commits

### DIFF
--- a/src/recyclerview/RecyclerView.tsx
+++ b/src/recyclerview/RecyclerView.tsx
@@ -444,9 +444,7 @@ const RecyclerViewComponent = <T,>(
           extraData={extraData}
           inverted={inverted}
           onChangeStickyIndex={(newStickyHeaderIndex) => {
-            if (stickyHeaderHideRelatedCell) {
-              setCurrentStickyIndex(newStickyHeaderIndex);
-            }
+            setCurrentStickyIndex(newStickyHeaderIndex);
             onChangeStickyIndex?.(newStickyHeaderIndex, currentStickyIndex);
           }}
         />
@@ -464,7 +462,6 @@ const RecyclerViewComponent = <T,>(
     extraData,
     currentStickyIndex,
     onChangeStickyIndex,
-    stickyHeaderHideRelatedCell,
     stickyHeaderZIndex,
     inverted,
   ]);
@@ -635,7 +632,7 @@ const RecyclerViewComponent = <T,>(
                 ? recyclerViewManager.getChildContainerDimensions()
                 : undefined
             }
-            currentStickyIndex={currentStickyIndex}
+            currentStickyIndex={stickyHeaders ? currentStickyIndex : -1}
             hideStickyHeaderRelatedCell={stickyHeaderHideRelatedCell}
             inverted={inverted}
           />

--- a/src/recyclerview/components/StickyHeaders.tsx
+++ b/src/recyclerview/components/StickyHeaders.tsx
@@ -85,20 +85,18 @@ export const StickyHeaders = <TItem,>({
 
   const { currentStickyIndex, pushStartsAt } = stickyHeaderState;
 
-  // sort indices and memoize compute
-  const sortedIndices = useMemo(() => {
-    return [...stickyHeaderIndices].sort((first, second) => first - second);
-  }, [stickyHeaderIndices]);
+  const dataLength = recyclerViewManager.getDataLength();
 
-  const lengthInvalid =
-    sortedIndices.length === 0 ||
-    recyclerViewManager.getDataLength() <=
-      sortedIndices[sortedIndices.length - 1];
+  // Ignore stale indices after data shrinks and invalid index values.
+  const sortedIndices = useMemo(() => {
+    return [...new Set(stickyHeaderIndices)]
+      .filter(
+        (index) => Number.isInteger(index) && index >= 0 && index < dataLength
+      )
+      .sort((first, second) => first - second);
+  }, [stickyHeaderIndices, dataLength]);
 
   const compute = useCallback(() => {
-    if (lengthInvalid) {
-      return;
-    }
     const adjustedScrollOffset = recyclerViewManager.getLastScrollOffset();
 
     // Binary search for current sticky index
@@ -126,7 +124,8 @@ export const StickyHeaders = <TItem,>({
       recyclerViewManager.tryGetLayout(newStickyIndex)?.height ?? 0;
 
     // Push should start when the next header reaches the bottom of the current sticky header
-    const newPushStartsAt = newNextStickyY - newCurrentStickyHeight;
+    const newPushStartsAt =
+      newNextStickyY - newCurrentStickyHeight - stickyHeaderOffset;
 
     if (
       newStickyIndex !== currentStickyIndex ||
@@ -134,7 +133,7 @@ export const StickyHeaders = <TItem,>({
     ) {
       setStickyHeaderState({
         currentStickyIndex: newStickyIndex,
-        pushStartsAt: newPushStartsAt - stickyHeaderOffset,
+        pushStartsAt: newPushStartsAt,
       });
     }
 
@@ -142,7 +141,6 @@ export const StickyHeaders = <TItem,>({
       onChangeStickyIndex?.(newStickyIndex);
     }
   }, [
-    lengthInvalid,
     recyclerViewManager,
     sortedIndices,
     currentStickyIndex,


### PR DESCRIPTION
## Fixes

Normalize sticky indices to sorted unique in-range integers, recompute when data/indices become empty, include configured offset before comparing push state, and retain current sticky index independently of hideRelatedCell. Removing sticky configuration restores the source cell.

## Compatibility / observable changes

No signature changes. Invalid/removed header indices no longer preserve a stale active header; previous-index callbacks and later hideRelatedCell changes use the actual tracked header.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - sticky headers skip redundant offset-state commits
  - sticky headers handle clear indices
  - sticky headers handle shrink indices
  - sticky headers handle invalid indices
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
