### PR TITLE
fix!: settle scroll requests on cancellation, unmount and failure

### DIFF
--- a/documentation/docs/fundamentals/usage.md
+++ b/documentation/docs/fundamentals/usage.md
@@ -862,10 +862,10 @@ Retriggers viewability calculations. Useful to imperatively trigger viewability 
 ### `scrollToEnd()`
 
 ```tsx
-scrollToEnd?: (params?: { animated?: boolean | null | undefined });
+scrollToEnd(params?: { animated?: boolean }): Promise<void>;
 ```
 
-Scrolls to the end of the content.
+Scrolls to the end of the content. The promise resolves after the native scroll command is dispatched, or if a newer index/item/end request supersedes it or the list unmounts. Scroll failures reject. Resolution does not mean the native animation has finished.
 
 ### `scrollToIndex()`
 
@@ -875,10 +875,10 @@ scrollToIndex(params: {
   index: number;
   viewOffset?: number | undefined;
   viewPosition?: number | undefined;
-});
+}): Promise<void>;
 ```
 
-Scroll to a given index.
+Scroll to a given index. The promise resolves after the settling delay, when superseded by another index/item/end request, or when the list unmounts. Invalid indices resolve without scrolling; layout and scroll failures reject.
 
 ### `scrollToItem()`
 
@@ -886,11 +886,14 @@ Scroll to a given index.
 scrollToItem(params: {
   animated?: boolean | null | undefined;
   item: any;
+  viewOffset?: number | undefined;
   viewPosition?: number | undefined;
-});
+}): Promise<void>;
 ```
 
-Scroll to a given item.
+Scroll to a given item, returning the underlying `scrollToIndex` promise. Missing items resolve without scrolling.
+
+`scrollToItem` and `scrollToEnd` now declare `Promise<void>` return values. Existing fire-and-forget calls remain valid, but typed mocks or custom ref implementations must return a promise. Await or catch the promise when handling scroll failures.
 
 ### `scrollToOffset()`
 

--- a/src/FlashListRef.ts
+++ b/src/FlashListRef.ts
@@ -135,6 +135,8 @@ export interface FlashListRef<T> {
 
   /**
    * Scrolls to the end of the list.
+   * Resolves after native dispatch or cancellation, not after the native animation.
+   * Layout and native scroll failures reject the returned promise.
    *
    * @param params - Optional parameters for scrolling
    * @param params.animated - Whether the scroll should be animated (default: false)
@@ -143,7 +145,7 @@ export interface FlashListRef<T> {
    * // Animate scroll to the end of the list
    * listRef.current?.scrollToEnd({ animated: true });
    */
-  scrollToEnd: (params?: ScrollToEdgeParams) => void;
+  scrollToEnd: (params?: ScrollToEdgeParams) => Promise<void>;
 
   /**
    * Scrolls to the top (or start) of the list.
@@ -169,7 +171,8 @@ export interface FlashListRef<T> {
    *                              0 = top/left, 0.5 = center, 1 = bottom/right (default: 0)
    * @param params.viewOffset - Additional offset to apply after viewPosition calculation
    *
-   * @returns A Promise that resolves when the scroll operation is complete
+   * @returns A Promise that resolves after the settling delay, when superseded by
+   * another index/item/end request, or when the list unmounts. Layout/scroll failures reject.
    *
    * @example
    * // Scroll to the 5th item (index 4) and center it
@@ -186,6 +189,7 @@ export interface FlashListRef<T> {
    *
    * Similar to scrollToIndex, but works with the item reference instead of its index.
    * Useful when you have a reference to an item but don't know its index.
+   * Returns scrollToIndex's completion; missing items resolve without scrolling.
    *
    * @param params - Parameters for scrolling to item
    * @param params.item - The item object to scroll to
@@ -202,7 +206,7 @@ export interface FlashListRef<T> {
    *   animated: true
    * });
    */
-  scrollToItem: (params: ScrollToItemParams<T>) => void;
+  scrollToItem: (params: ScrollToItemParams<T>) => Promise<void>;
 
   /**
    * Returns the offset of the first item (accounts for header/padding).

--- a/src/recyclerview/hooks/useRecyclerViewController.tsx
+++ b/src/recyclerview/hooks/useRecyclerViewController.tsx
@@ -2,6 +2,7 @@ import {
   RefObject,
   useCallback,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -60,6 +61,18 @@ export function useRecyclerViewController<T>(
 
   // Queue to store callbacks that should be executed after scroll offset updates
   const pendingScrollCallbacks = useRef<(() => void)[]>([]);
+  const activeScrollRequest = useRef<{ complete: () => void } | null>(null);
+  const scrollCommandId = useRef(0);
+  const pendingEndCompletions = useRef(new Set<() => void>());
+
+  useLayoutEffect(() => {
+    const endCompletions = pendingEndCompletions.current;
+    return () => {
+      pendingScrollCallbacks.current = [];
+      activeScrollRequest.current?.complete();
+      endCompletions.forEach((complete) => complete());
+    };
+  }, []);
 
   // Handle initial scroll position when the list first loads
   //   useOnLoad(recyclerViewManager, () => {
@@ -287,19 +300,41 @@ export function useRecyclerViewController<T>(
        * Scrolls to the end of the list.
        */
       scrollToEnd: async ({ animated }: ScrollToEdgeParams = {}) => {
+        if (isUnmounted.current) return;
+        activeScrollRequest.current?.complete();
+        let commandId = ++scrollCommandId.current;
         const { data } = recyclerViewManager.props;
         if (data && data.length > 0) {
           const lastIndex = data.length - 1;
           if (!recyclerViewManager.getEngagedIndices().includes(lastIndex)) {
-            await handlerMethods.scrollToIndex({
+            const preparation = handlerMethods.scrollToIndex({
               index: lastIndex,
               animated,
             });
+            commandId = scrollCommandId.current;
+            await preparation;
           }
         }
-        setTimeout(() => {
-          scrollViewRef.current?.scrollToEnd({ animated });
-        }, 0);
+        if (isUnmounted.current || commandId !== scrollCommandId.current)
+          return;
+        return new Promise<void>((resolve, reject) => {
+          const complete = () => {
+            pendingEndCompletions.current.delete(complete);
+            resolve();
+          };
+          pendingEndCompletions.current.add(complete);
+          setTimeout(() => {
+            try {
+              if (commandId === scrollCommandId.current) {
+                scrollViewRef.current?.scrollToEnd({ animated });
+              }
+              complete();
+            } catch (error) {
+              pendingEndCompletions.current.delete(complete);
+              reject(error);
+            }
+          }, 0);
+        });
       },
 
       /**
@@ -323,177 +358,206 @@ export function useRecyclerViewController<T>(
         viewPosition,
         viewOffset,
       }: ScrollToIndexParams): Promise<void> => {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
           const { horizontal } = recyclerViewManager.props;
           if (
             scrollViewRef.current &&
+            !isUnmounted.current &&
+            Number.isInteger(index) &&
             index >= 0 &&
             index < recyclerViewManager.getDataLength()
           ) {
-            // Pause the scroll offset adjustments
-            pauseOffsetCorrection.current = true;
-            recyclerViewManager.setOffsetProjectionEnabled(false);
-
-            const getFinalOffset = () => {
-              const layout = recyclerViewManager.getLayout(index);
-              const offset = horizontal ? layout.x : layout.y;
-              let finalOffset = offset;
-              // take viewPosition etc into account
-              if (viewPosition !== undefined || viewOffset !== undefined) {
-                const containerSize = horizontal
-                  ? recyclerViewManager.getWindowSize().width
-                  : recyclerViewManager.getWindowSize().height;
-
-                const itemSize = horizontal ? layout.width : layout.height;
-
-                if (viewPosition !== undefined) {
-                  // viewPosition: 0 = top, 0.5 = center, 1 = bottom
-                  finalOffset =
-                    offset - (containerSize - itemSize) * viewPosition;
-                }
-
-                if (viewOffset !== undefined) {
-                  finalOffset += viewOffset;
-                }
+            activeScrollRequest.current?.complete();
+            scrollCommandId.current++;
+            const release = () => {
+              if (activeScrollRequest.current === request) {
+                activeScrollRequest.current = null;
+                pauseOffsetCorrection.current = false;
+                recyclerViewManager.setOffsetProjectionEnabled(true);
               }
-              return finalOffset + recyclerViewManager.firstItemOffset;
             };
-            const lastAbsoluteScrollOffset =
-              recyclerViewManager.getAbsoluteLastScrollOffset();
-            const bufferForScroll = horizontal
-              ? recyclerViewManager.getWindowSize().width
-              : recyclerViewManager.getWindowSize().height;
-
-            const bufferForCompute = bufferForScroll * 2;
-
-            const getStartScrollOffset = () => {
-              let lastScrollOffset = lastAbsoluteScrollOffset;
-              const finalOffset = getFinalOffset();
-
-              if (finalOffset > lastScrollOffset) {
-                lastScrollOffset = Math.max(
-                  finalOffset - bufferForCompute,
-                  lastScrollOffset
-                );
-                recyclerViewManager.setScrollDirection("forward");
-              } else {
-                lastScrollOffset = Math.min(
-                  finalOffset + bufferForCompute,
-                  lastScrollOffset
-                );
-                recyclerViewManager.setScrollDirection("backward");
-              }
-              return lastScrollOffset;
-            };
-            let initialTargetOffset = getFinalOffset();
-            let initialStartScrollOffset = getStartScrollOffset();
-            let finalOffset = initialTargetOffset;
-            let startScrollOffset = initialStartScrollOffset;
-
-            const steps = 5;
-
-            /**
-             * Recursively performs the scroll animation steps.
-             * This function replaces the async/await loop with callback-based execution.
-             *
-             * @param currentStep - The current step in the animation (0 to steps-1)
-             */
-            const performScrollStep = (currentStep: number) => {
-              // Check if component is unmounted or we've completed all steps
-              if (isUnmounted.current) {
+            const request = {
+              complete: () => {
+                release();
                 resolve();
-                return;
-              } else if (currentStep >= steps) {
-                // All steps completed, perform final scroll
-                finishScrollToIndex();
+              },
+            };
+            activeScrollRequest.current = request;
+            const runSafely = (callback: () => void) => {
+              if (activeScrollRequest.current !== request) return;
+              if (isUnmounted.current) {
+                request.complete();
                 return;
               }
+              try {
+                callback();
+              } catch (error) {
+                release();
+                reject(error);
+              }
+            };
+            runSafely(() => {
+              // Pause the scroll offset adjustments
+              pauseOffsetCorrection.current = true;
+              recyclerViewManager.setOffsetProjectionEnabled(false);
 
-              // Calculate the offset for this step
-              // For animated scrolls: interpolate from finalOffset to startScrollOffset
-              // For non-animated: interpolate from startScrollOffset to finalOffset
-              const nextOffset = animated
-                ? finalOffset +
-                  (startScrollOffset - finalOffset) *
-                    (currentStep / (steps - 1))
-                : startScrollOffset +
-                  (finalOffset - startScrollOffset) *
-                    (currentStep / (steps - 1));
+              const getFinalOffset = () => {
+                const layout = recyclerViewManager.getLayout(index);
+                const offset = horizontal ? layout.x : layout.y;
+                let finalOffset = offset;
+                // take viewPosition etc into account
+                if (viewPosition !== undefined || viewOffset !== undefined) {
+                  const containerSize = horizontal
+                    ? recyclerViewManager.getWindowSize().width
+                    : recyclerViewManager.getWindowSize().height;
 
-              // Update scroll offset with a callback to continue to the next step
-              updateScrollOffsetWithCallback(nextOffset, () => {
-                // Check if the index is still valid after the update
-                if (index >= recyclerViewManager.getDataLength()) {
-                  // Index out of bounds, scroll to end instead
-                  handlerMethods.scrollToEnd({ animated });
-                  resolve(); // Resolve the promise as we're done
+                  const itemSize = horizontal ? layout.width : layout.height;
+
+                  if (viewPosition !== undefined) {
+                    // viewPosition: 0 = top, 0.5 = center, 1 = bottom
+                    finalOffset =
+                      offset - (containerSize - itemSize) * viewPosition;
+                  }
+
+                  if (viewOffset !== undefined) {
+                    finalOffset += viewOffset;
+                  }
+                }
+                return finalOffset + recyclerViewManager.firstItemOffset;
+              };
+              const lastAbsoluteScrollOffset =
+                recyclerViewManager.getAbsoluteLastScrollOffset();
+              const bufferForScroll = horizontal
+                ? recyclerViewManager.getWindowSize().width
+                : recyclerViewManager.getWindowSize().height;
+
+              const bufferForCompute = bufferForScroll * 2;
+
+              const getStartScrollOffset = () => {
+                let lastScrollOffset = lastAbsoluteScrollOffset;
+                const finalOffset = getFinalOffset();
+
+                if (finalOffset > lastScrollOffset) {
+                  lastScrollOffset = Math.max(
+                    finalOffset - bufferForCompute,
+                    lastScrollOffset
+                  );
+                  recyclerViewManager.setScrollDirection("forward");
+                } else {
+                  lastScrollOffset = Math.min(
+                    finalOffset + bufferForCompute,
+                    lastScrollOffset
+                  );
+                  recyclerViewManager.setScrollDirection("backward");
+                }
+                return lastScrollOffset;
+              };
+              let initialTargetOffset = getFinalOffset();
+              let initialStartScrollOffset = getStartScrollOffset();
+              let finalOffset = initialTargetOffset;
+              let startScrollOffset = initialStartScrollOffset;
+
+              const steps = 5;
+
+              /**
+               * Recursively performs the scroll animation steps.
+               * This function replaces the async/await loop with callback-based execution.
+               *
+               * @param currentStep - The current step in the animation (0 to steps-1)
+               */
+              const performScrollStep = (currentStep: number) => {
+                // Check if component is unmounted or we've completed all steps
+                if (isUnmounted.current) {
+                  request.complete();
+                  return;
+                } else if (currentStep >= steps) {
+                  // All steps completed, perform final scroll
+                  finishScrollToIndex();
                   return;
                 }
 
-                // Check if the target position has changed significantly
-                const newFinalOffset = getFinalOffset();
-                if (
-                  (newFinalOffset < initialTargetOffset &&
-                    newFinalOffset < initialStartScrollOffset) ||
-                  (newFinalOffset > initialTargetOffset &&
-                    newFinalOffset > initialStartScrollOffset)
-                ) {
-                  // Target has moved, recalculate and restart from beginning
-                  finalOffset = newFinalOffset;
-                  startScrollOffset = getStartScrollOffset();
-                  initialTargetOffset = newFinalOffset;
-                  initialStartScrollOffset = startScrollOffset;
-                  performScrollStep(0); // Restart from step 0
-                } else {
-                  // Continue to next step
-                  performScrollStep(currentStep + 1);
+                // Calculate the offset for this step
+                // For animated scrolls: interpolate from finalOffset to startScrollOffset
+                // For non-animated: interpolate from startScrollOffset to finalOffset
+                const nextOffset = animated
+                  ? finalOffset +
+                    (startScrollOffset - finalOffset) *
+                      (currentStep / (steps - 1))
+                  : startScrollOffset +
+                    (finalOffset - startScrollOffset) *
+                      (currentStep / (steps - 1));
+
+                // Update scroll offset with a callback to continue to the next step
+                updateScrollOffsetWithCallback(nextOffset, () =>
+                  runSafely(() => {
+                    // Check if the index is still valid after the update
+                    if (index >= recyclerViewManager.getDataLength()) {
+                      // Index out of bounds, scroll to end instead
+                      release();
+                      return Promise.resolve(
+                        handlerMethods.scrollToEnd({ animated })
+                      ).then(resolve, reject);
+                    }
+
+                    // Check if the target position has changed significantly
+                    const newFinalOffset = getFinalOffset();
+                    if (
+                      (newFinalOffset < initialTargetOffset &&
+                        newFinalOffset < initialStartScrollOffset) ||
+                      (newFinalOffset > initialTargetOffset &&
+                        newFinalOffset > initialStartScrollOffset)
+                    ) {
+                      // Target has moved, recalculate and restart from beginning
+                      finalOffset = newFinalOffset;
+                      startScrollOffset = getStartScrollOffset();
+                      initialTargetOffset = newFinalOffset;
+                      initialStartScrollOffset = startScrollOffset;
+                      performScrollStep(0); // Restart from step 0
+                    } else {
+                      // Continue to next step
+                      performScrollStep(currentStep + 1);
+                    }
+                  })
+                );
+              };
+
+              /**
+               * Completes the scroll to index operation by performing the final scroll
+               * and re-enabling offset correction after a delay.
+               */
+              const finishScrollToIndex = () => {
+                finalOffset = getFinalOffset();
+                const maxOffset = recyclerViewManager.getMaxScrollOffset();
+
+                if (finalOffset > maxOffset) {
+                  finalOffset = maxOffset;
                 }
-              });
-            };
 
-            /**
-             * Completes the scroll to index operation by performing the final scroll
-             * and re-enabling offset correction after a delay.
-             */
-            const finishScrollToIndex = () => {
-              finalOffset = getFinalOffset();
-              const maxOffset = recyclerViewManager.getMaxScrollOffset();
+                if (animated) {
+                  // For animated scrolls, first jump to the start position
+                  // We don't need to add firstItemOffset here as it's already added
+                  handlerMethods.scrollToOffset({
+                    offset: startScrollOffset,
+                    animated: false,
+                    skipFirstItemOffset: true,
+                  });
+                }
 
-              if (finalOffset > maxOffset) {
-                finalOffset = maxOffset;
-              }
-
-              if (animated) {
-                // For animated scrolls, first jump to the start position
-                // We don't need to add firstItemOffset here as it's already added
+                // Perform the final scroll to the target position
                 handlerMethods.scrollToOffset({
-                  offset: startScrollOffset,
-                  animated: false,
+                  offset: finalOffset,
+                  animated,
                   skipFirstItemOffset: true,
                 });
-              }
 
-              // Perform the final scroll to the target position
-              handlerMethods.scrollToOffset({
-                offset: finalOffset,
-                animated,
-                skipFirstItemOffset: true,
-              });
+                // Re-enable offset correction after a delay
+                // Longer delay for animated scrolls to allow animation to complete
+                setTimeout(request.complete, animated ? 300 : 200);
+              };
 
-              // Re-enable offset correction after a delay
-              // Longer delay for animated scrolls to allow animation to complete
-              setTimeout(
-                () => {
-                  pauseOffsetCorrection.current = false;
-                  recyclerViewManager.setOffsetProjectionEnabled(true);
-                  resolve(); // Resolve the promise after re-enabling corrections
-                },
-                animated ? 300 : 200
-              );
-            };
-
-            // Start the scroll animation process
-            performScrollStep(0);
+              // Start the scroll animation process
+              performScrollStep(0);
+            });
           } else {
             // Invalid parameters, resolve immediately
             resolve();
@@ -505,7 +569,7 @@ export function useRecyclerViewController<T>(
        * Scrolls to a specific item in the list.
        * Finds the item's index and uses scrollToIndex internally.
        */
-      scrollToItem: ({
+      scrollToItem: async ({
         item,
         animated,
         viewPosition,
@@ -516,7 +580,7 @@ export function useRecyclerViewController<T>(
           // Find the index of the item in the data array
           const index = data.findIndex((dataItem) => dataItem === item);
           if (index >= 0) {
-            handlerMethods.scrollToIndex({
+            return handlerMethods.scrollToIndex({
               index,
               animated,
               viewPosition,


### PR DESCRIPTION
## Fixes

Give each index scroll request ownership of offset correction, settle superseded/unmounted requests, reject setup/measurement/native failures and prevent stale end requests from overriding newer commands. Forward item completion and await end dispatch. Preserve existing scroll-step and settling delays.

## Compatibility / observable changes

Type-level compatibility change: scrollToItem and scrollToEnd now explicitly return Promise<void>. Typed mocks/custom FlashListRef implementations must return promises. Fire-and-forget usage remains valid, but callers that need errors must await/catch. End completion means native dispatch/cancellation, not animation completion. Index/item completion also occurs on supersession or unmount.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - scroll request settles on unmount during timeout
  - scroll request settles on unmount before layout
  - scroll request older timeout cannot restore projection during successor
  - scroll request releases projection after setup failure
  - scroll-to-item returns the underlying completion promise
  - scroll-to-end awaits native dispatch and propagates errors
  - scroll-to-end settles when unmounted before dispatch
  - stale scroll-to-end cannot override a newer index request
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
