### PR TITLE
fix(example): cancel stale refreshes and handle empty scroll controls

### DIFF
--- a/fixture/react-native/src/RecyclerViewHandlerTest.tsx
+++ b/fixture/react-native/src/RecyclerViewHandlerTest.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -48,20 +48,38 @@ const generateItems = (count: number): Item[] => {
 };
 
 const RecyclerViewHandlerTest = () => {
-  const [items, setItems] = useState<Item[]>(generateItems(100));
+  const [items, setItems] = useState<Item[]>(() => generateItems(100));
   const [horizontal, setHorizontal] = useState(false);
   const [lastAction, setLastAction] = useState("None");
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Reference to the FlashList
   const listRef = useRef<any>(null);
+  const refreshTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelRefresh = useCallback(() => {
+    if (refreshTimeout.current !== null) {
+      clearTimeout(refreshTimeout.current);
+      refreshTimeout.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelRefresh, [cancelRefresh]);
+
+  const resetItems = (count: number) => {
+    cancelRefresh();
+    setIsRefreshing(false);
+    setItems(generateItems(count));
+  };
 
   // Handle refresh
   const handleRefresh = () => {
+    if (refreshTimeout.current !== null) return;
     setIsRefreshing(true);
 
     // Simulate network request
-    setTimeout(() => {
+    refreshTimeout.current = setTimeout(() => {
+      refreshTimeout.current = null;
       setItems(generateItems(100));
       setIsRefreshing(false);
       setLastAction("Refreshed list");
@@ -103,12 +121,12 @@ const RecyclerViewHandlerTest = () => {
   };
 
   const scrollToItem = (
-    item: Item,
+    item: Item | undefined,
     animated = true,
     viewPosition?: number,
     viewOffset?: number
   ) => {
-    if (listRef.current) {
+    if (listRef.current && item !== undefined) {
       listRef.current.scrollToItem({
         item,
         animated,
@@ -275,7 +293,7 @@ const RecyclerViewHandlerTest = () => {
           <View style={styles.controlRow}>
             <TouchableOpacity
               style={styles.button}
-              onPress={() => setItems([])}
+              onPress={() => resetItems(0)}
             >
               <Text style={styles.buttonText}>Clear Items</Text>
             </TouchableOpacity>
@@ -284,7 +302,7 @@ const RecyclerViewHandlerTest = () => {
           <View style={styles.controlRow}>
             <TouchableOpacity
               style={styles.button}
-              onPress={() => setItems(generateItems(100))}
+              onPress={() => resetItems(100)}
             >
               <Text style={styles.buttonText}>Reset Items</Text>
             </TouchableOpacity>

--- a/fixture/web/RecyclerViewHandlerTest.tsx
+++ b/fixture/web/RecyclerViewHandlerTest.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   View,
   Text,
@@ -49,20 +55,38 @@ const generateItems = (count: number): Item[] => {
 };
 
 const RecyclerViewHandlerTest = () => {
-  const [items, setItems] = useState<Item[]>(generateItems(10000));
+  const [items, setItems] = useState<Item[]>(() => generateItems(10000));
   const [horizontal, setHorizontal] = useState(false);
   const [lastAction, setLastAction] = useState("None");
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Reference to the FlashList
   const listRef = useRef<any>(null);
+  const refreshTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelRefresh = useCallback(() => {
+    if (refreshTimeout.current !== null) {
+      clearTimeout(refreshTimeout.current);
+      refreshTimeout.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelRefresh, [cancelRefresh]);
+
+  const resetItems = (count: number) => {
+    cancelRefresh();
+    setIsRefreshing(false);
+    setItems(generateItems(count));
+  };
 
   // Handle refresh
   const handleRefresh = () => {
+    if (refreshTimeout.current !== null) return;
     setIsRefreshing(true);
 
     // Simulate network request
-    setTimeout(() => {
+    refreshTimeout.current = setTimeout(() => {
+      refreshTimeout.current = null;
       setItems(generateItems(100));
       setIsRefreshing(false);
       setLastAction("Refreshed list");
@@ -104,12 +128,12 @@ const RecyclerViewHandlerTest = () => {
   };
 
   const scrollToItem = (
-    item: Item,
+    item: Item | undefined,
     animated = true,
     viewPosition?: number,
     viewOffset?: number
   ) => {
-    if (listRef.current) {
+    if (listRef.current && item !== undefined) {
       listRef.current.scrollToItem({
         item,
         animated,
@@ -286,7 +310,7 @@ const RecyclerViewHandlerTest = () => {
           <View style={styles.controlRow}>
             <TouchableOpacity
               style={styles.button}
-              onPress={() => setItems([])}
+              onPress={() => resetItems(0)}
             >
               <Text style={styles.buttonText}>Clear Items</Text>
             </TouchableOpacity>
@@ -295,7 +319,7 @@ const RecyclerViewHandlerTest = () => {
           <View style={styles.controlRow}>
             <TouchableOpacity
               style={styles.button}
-              onPress={() => setItems(generateItems(100))}
+              onPress={() => resetItems(100)}
             >
               <Text style={styles.buttonText}>Reset Items</Text>
             </TouchableOpacity>
@@ -328,7 +352,7 @@ const RecyclerViewHandlerTest = () => {
             ref={listRef}
             key={horizontal ? "horizontal" : "vertical"}
             data={items}
-            numColumns={numColumns}
+            numColumns={horizontal ? 1 : numColumns}
             renderItem={renderItem}
             horizontal={horizontal}
             ListHeaderComponent={ListHeaderComponent}


### PR DESCRIPTION
## Fixes

Lazily generate initial data, keep one owned refresh timer, clear it on reset/clear/unmount, ignore duplicate refreshes and avoid dereferencing an absent scroll-to-item target. Use one column in horizontal web mode.

## Compatibility / observable changes

Example-only changes. Clearing/resetting cannot be undone by an old refresh; empty scroll-to-item controls are safe. No library API change.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- One-off actual-source regression diagnostics pass:
  - fixture/react-native/src/RecyclerViewHandlerTest cancels refresh on unmount
  - fixture/react-native/src/RecyclerViewHandlerTest cancels refresh on clear
  - fixture/react-native/src/RecyclerViewHandlerTest cancels refresh on reset
  - fixture/react-native/src/RecyclerViewHandlerTest ignores duplicate refresh requests
  - fixture/react-native/src/RecyclerViewHandlerTest handles scroll-to-item after clear
  - fixture/web/RecyclerViewHandlerTest cancels refresh on unmount
  - fixture/web/RecyclerViewHandlerTest cancels refresh on clear
  - fixture/web/RecyclerViewHandlerTest cancels refresh on reset
  - fixture/web/RecyclerViewHandlerTest ignores duplicate refresh requests
  - fixture/web/RecyclerViewHandlerTest handles scroll-to-item after clear
  - web horizontal mode uses one column
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
