### PR TITLE
fix(types): isolate fixture build output and accept nullable benchmark refs

### DIFF
--- a/fixture/react-native/package.json
+++ b/fixture/react-native/package.json
@@ -7,7 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "build": "tsc -b",
+    "build": "tsc -b ../../ && tsc -b",
     "e2e:test:ios": "detox test -c ios.sim.release --artifacts-location /tmp/detox_artifacts/",
     "e2e:build:ios": "detox build -c ios.sim.release",
     "e2e:test:android": "detox test -c android.emu.release --artifacts-location /tmp/detox_artifacts/",

--- a/fixture/react-native/src/twitter/Twitter.tsx
+++ b/fixture/react-native/src/twitter/Twitter.tsx
@@ -17,14 +17,9 @@ import Tweet from "./models/Tweet";
 export interface TwitterProps {
   instance?: React.RefObject<FlashListRef<Tweet>>;
   CellRendererComponent?: React.ComponentType<any>;
-  disableAutoLayout?: boolean;
 }
 
-const Twitter = ({
-  instance,
-  CellRendererComponent,
-  disableAutoLayout,
-}: TwitterProps) => {
+const Twitter = ({ instance, CellRendererComponent }: TwitterProps) => {
   const debugContext = useContext(DebugContext);
   const [refreshing, setRefreshing] = useState(false);
   const remainingTweets = useRef([...tweetsData].splice(10, tweetsData.length));
@@ -38,7 +33,6 @@ const Twitter = ({
   }).current;
 
   return (
-    // @ts-ignore - Type compatibility issue between different React versions
     <FlashList
       ref={instance}
       testID="FlashList"
@@ -58,7 +52,6 @@ const Twitter = ({
           setTweets(reversedTweets);
         }, 500);
       }}
-      // @ts-ignore - Type compatibility issue between different React versions
       CellRendererComponent={CellRendererComponent}
       onEndReached={() => {
         if (!debugContext.pagingEnabled) {
@@ -77,7 +70,6 @@ const Twitter = ({
         />
       }
       ListEmptyComponent={Empty()}
-      estimatedItemSize={150}
       ItemSeparatorComponent={Divider}
       data={debugContext.emptyListEnabled ? [] : tweets}
       initialScrollIndex={debugContext.initialScrollIndex}
@@ -85,7 +77,6 @@ const Twitter = ({
       onViewableItemsChanged={(info) => {
         console.log(info);
       }}
-      disableAutoLayout={disableAutoLayout}
     />
   );
 };

--- a/fixture/react-native/tsconfig.json
+++ b/fixture/react-native/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "../../shared/tsconfig.base.json",
-  "references": [{ "path": "../../" }],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "react": ["./node_modules/@types/react"],
+      "react-native": ["./node_modules/react-native"]
+    }
+  },
   "include": ["src/**/*", "e2e/**/*"]
 }

--- a/src/benchmark/useBenchmark.ts
+++ b/src/benchmark/useBenchmark.ts
@@ -46,7 +46,7 @@ export interface BenchmarkResult {
  */
 
 export function useBenchmark(
-  flashListRef: React.RefObject<FlashListRef<any>>,
+  flashListRef: React.RefObject<FlashListRef<any> | null>,
   callback: (benchmarkResult: BenchmarkResult) => void,
   params: BenchmarkParams = {}
 ) {

--- a/src/benchmark/useFlatListBenchmark.ts
+++ b/src/benchmark/useFlatListBenchmark.ts
@@ -21,7 +21,7 @@ export interface FlatListBenchmarkParams extends BenchmarkParams {
  * It's recommended to remove pagination while running the benchmark. Removing the onEndReached callback is the easiest way to do that.
  */
 export function useFlatListBenchmark(
-  flatListRef: React.RefObject<FlatList<any>>,
+  flatListRef: React.RefObject<FlatList<any> | null>,
   callback: (benchmarkResult: BenchmarkResult) => void,
   params: FlatListBenchmarkParams
 ) {


### PR DESCRIPTION
## Fixes

Emit fixture build output/build-info into its dist directory rather than next to source and e2e files. Build the library first and resolve fixture React/RN declarations from the fixture so React 18 library declarations do not collide with the React 19 example. Accept ordinary nullable useRef values in benchmark hook signatures. Remove retired v1 Twitter fixture props and the no-longer-needed React-version suppressions so this type-checking change builds independently.

## Compatibility / observable changes

No breaking API change. Benchmark ref inputs are broadened to accept null explicitly under React 19. Generated fixture JS/declarations move to dist; source/e2e files no longer get shadowing build products.

## Verification

- Consumer verification: the combined fixes were packaged on the unchanged npm 2.3.2 runtime baseline and checked with React Native 0.87.1 / React 19.2.3. Immutable install, lint, both Android Debug variants, both unsigned iOS Simulator variants, four Metro bundles, 13 web targets and four browser-extension builds pass. All 298 installed non-metadata package files match the reviewed artifact byte-for-byte.
- Independent patch applied to `435b5141df4960ebbbc0b93264db3f5a4b23fffd`: all 187 existing tests (14 suites), library TypeScript build and changed-file ESLint pass.
- The native fixture TypeScript build also passes independently with its own React 19 dependencies.
- The combined review workspace passes Android Debug, unsigned iOS Simulator Debug/Release, both production Metro bundles, web production export, Docusaurus/Jekyll builds and all 24 existing iOS Detox tests (10 suites). The contacts comparison was rerun after its final change. These combined-workspace results are not a claim that every device/platform was tested independently for this PR.
- No checked-in tests, reference screenshots, dependency versions or native SDK versions were changed.

## Reviewers’ hat-rack :tophat:

- [ ] Check the stated compatibility behavior and reproduce the relevant cases above.
- [ ] Run the existing test/type/lint commands and exercise the affected example or list behavior on your supported device matrix.

Physical-device behavior, Android Detox, assistive-technology conformance and release signing were not verified. No app deployment is part of this PR.
