### PR TITLE
Fix viewability callbacks after data updates

### DIFF
--- a/src/__tests__/RecyclerView.test.tsx
+++ b/src/__tests__/RecyclerView.test.tsx
@@ -162,6 +162,32 @@ describe("RecyclerView", () => {
     });
   });
 
+  describe("Viewability after data updates", () => {
+    it("reports visible items when data is replaced at the same indices", () => {
+      const onViewableItemsChanged = jest.fn();
+      const result = render(
+        <FlashList
+          data={[{ id: "a" }]}
+          keyExtractor={(item) => item.id}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={{ minimumViewTime: 0 }}
+          renderItem={({ item }) => <Text>{item.id}</Text>}
+        />
+      );
+
+      result.act(() => jest.runAllTimers());
+      onViewableItemsChanged.mockClear();
+
+      result.setProps({ data: [{ id: "b" }] });
+      result.act(() => jest.runAllTimers());
+
+      expect(onViewableItemsChanged).toHaveBeenCalledWith({
+        viewableItems: [expect.objectContaining({ item: { id: "b" } })],
+        changed: [expect.objectContaining({ item: { id: "b" } })],
+      });
+    });
+  });
+
   describe("Item separators in grid mode", () => {
     const Separator = () => <View style={{ height: 10 }} />;
 

--- a/src/recyclerview/RecyclerViewManager.ts
+++ b/src/recyclerview/RecyclerViewManager.ts
@@ -300,6 +300,7 @@ export class RecyclerViewManager<T> {
   }
 
   processDataUpdate() {
+    this.itemViewabilityManager.clearLastReportedViewableIndices();
     if (this.hasLayout()) {
       this.modifyChildrenLayout([], this.propsRef.data?.length ?? 0);
       if (this.hasRenderedProgressively && !this.recomputeEngagedIndices()) {


### PR DESCRIPTION
## Description

When the `data` reference changed but the visible indices stayed the same, the viewability helper retained its index cache and suppressed `onViewableItemsChanged`. Consumers therefore continued to hold tokens for the previous items until scrolling changed visibility.

Reset the existing viewability cache in the data-update path so the post-commit visibility calculation reports the replacement items. This matches React Native VirtualizedList behavior while leaving normal scroll calculations unchanged.

## Reviewers’ hat-rack :tophat:

- [ ] Replace visible keyed data without scrolling and verify the callback receives the new item.
- [ ] Confirm ordinary scrolling still avoids duplicate callbacks.

## Verification

- `jest --runInBand` — 188 tests passed
- `eslint . --ext .ts,.tsx`
- `tsc --pretty --noEmit`
- `react-doctor . --verbose --diff` — 100/100
- `git diff --check`

## Screenshots or videos (if needed)

Not applicable.