### PR TITLE
fix: refresh recycling when extraData changes

### DIFF
--- a/src/__tests__/useRecyclerViewManager.test.tsx
+++ b/src/__tests__/useRecyclerViewManager.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render } from "@quilted/react-testing";
+
+import { FlashListProps } from "../FlashListProps";
+import { RecyclerViewManager } from "../recyclerview/RecyclerViewManager";
+import { useRecyclerViewManager } from "../recyclerview/hooks/useRecyclerViewManager";
+
+const TestComponent = <T,>({
+  listProps,
+  onRender,
+}: {
+  listProps: FlashListProps<T>;
+  onRender: (manager: RecyclerViewManager<T>) => void;
+}) => {
+  const { recyclerViewManager } = useRecyclerViewManager(listProps);
+  onRender(recyclerViewManager);
+  return null;
+};
+
+describe("useRecyclerViewManager", () => {
+  it("reassigns item types when extraData changes", () => {
+    const data = [{ id: 1 }];
+    let itemType = "standard";
+    let manager: RecyclerViewManager<typeof data[number]> | undefined;
+    const listProps: FlashListProps<typeof data[number]> = {
+      data,
+      extraData: { version: 1 },
+      getItemType: () => itemType,
+      renderItem: jest.fn(),
+    };
+    const component = render(
+      <TestComponent
+        listProps={listProps}
+        onRender={(currentManager) => {
+          manager = currentManager;
+        }}
+      />
+    );
+
+    manager?.updateLayoutParams({ width: 100, height: 100 }, 0);
+    manager?.processDataUpdate();
+    expect(Array.from(manager?.getRenderStack().values() ?? [])).toEqual([
+      expect.objectContaining({ itemType: "standard" }),
+    ]);
+
+    itemType = "featured";
+    component.setProps({
+      listProps: {
+        ...listProps,
+        extraData: { version: 2 },
+      },
+    });
+
+    expect(Array.from(manager?.getRenderStack().values() ?? [])).toEqual([
+      expect.objectContaining({ itemType: "featured" }),
+    ]);
+  });
+});

--- a/src/recyclerview/hooks/useRecyclerViewManager.ts
+++ b/src/recyclerview/hooks/useRecyclerViewManager.ts
@@ -10,7 +10,7 @@ export const useRecyclerViewManager = <T>(props: RecyclerViewProps<T>) => {
   );
   const [velocityTracker] = useState(() => new VelocityTracker());
 
-  const { data } = props;
+  const { data, extraData } = props;
 
   useMemo(() => {
     recyclerViewManager.updateProps(props);
@@ -19,13 +19,13 @@ export const useRecyclerViewManager = <T>(props: RecyclerViewProps<T>) => {
   }, [props]);
 
   /**
-   * When data changes, we need to process the data update before the render happens
+   * When data or extraData changes, process the layout update before render.
    */
   useMemo(() => {
     recyclerViewManager.processDataUpdate();
     // used to process data update so rule can be disabled
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data]);
+  }, [data, extraData]);
 
   useEffect(() => {
     recyclerViewManager.restoreIfNeeded();


### PR DESCRIPTION
## Fix

Include `extraData` in the recycler data-update trigger so changing it re-evaluates active item types before render.

## Problem

`extraData` is the documented marker for list output that depends on state outside `data`. The recycler only processed updates when the `data` reference changed, so an `extraData`-only render could leave active cells assigned to their previous item-type pool.

The regression initializes a real render stack, changes only `extraData`, and verifies that the active item is reassigned from `standard` to `featured`. It fails on untouched `main` and passes with the dependency change.

## Compatibility / observable changes

- public APIs and callback signatures are unchanged
- `extraData` identity changes now perform the same recycler update already used for `data` changes
- unchanged `extraData` does not add work
- this is independent from #2472, which forwards `extraData` into the callback itself

No breaking change is intended.

## Verification

- focused regression passes
- full Jest suite: 15 suites, 188 tests passed
- library TypeScript check passed
- changed-file ESLint and `git diff --check` passed
- React Doctor: 100/100
- no dependency, lockfile, native SDK, or Songstats application change

## Reviewers’ hat-rack :tophat:

- [ ] Verify the `extraData`-only recycling case and intended update cost.
- [ ] Run the existing test/type/lint commands on a supported environment.