### PR TITLE
[LOW] Pin CLA action to an immutable commit

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ jobs:
       ) 
       || (github.event.pull_request && !github.event.pull_request.merged)
     steps:
-      - uses: Shopify/shopify-cla-action@v1
+      - uses: Shopify/shopify-cla-action@9938f4b43524d1cfa7471ce9a803edf226697284 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cla-token: ${{ secrets.CLA_TOKEN }}


### PR DESCRIPTION
## Description

The CLA workflow currently references the mutable `Shopify/shopify-cla-action@v1` tag while passing both the repository token and `CLA_TOKEN` to that action. If the tag is moved unexpectedly, the workflow would execute different code with those credentials.

This pins the action to the commit currently referenced by `v1`, while retaining the version comment for Dependabot and human readability. Runtime behavior is unchanged.

Severity: **LOW**. This is supply-chain hardening; no compromise or active exploitation is known or claimed.

## Reviewers’ hat-rack :tophat:

- [ ] Confirm `9938f4b43524d1cfa7471ce9a803edf226697284` is the intended `v1` revision.
- [ ] Confirm the CLA workflow still receives the same inputs.

Verification:

- Workflow YAML parses successfully.
- The pinned SHA matches the current upstream `refs/tags/v1` target.
- The repository baseline passes: 14 Jest suites / 187 tests, type-check, lint, and build.
- `git diff --check` passes.

No regression test was added because this is a one-line declarative action reference; the exact ref and YAML structure were checked directly.

## Screenshots or videos (if needed)

Not applicable.
