### PR TITLE
[LOW] Reduce release workflow token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       id-token: write
     steps:
       - name: Set tag name


### PR DESCRIPTION
## Description

The npm release job currently receives `contents: write` and `pull-requests: write`, although it only checks out the tagged source and publishes through npm trusted publishing.

This applies least privilege to that job:

- `contents: read` remains available for checkout.
- `id-token: write` remains available for npm OIDC trusted publishing.
- Unused repository-content and pull-request write access is removed.

Severity: **LOW**. This limits the impact of a compromised release step without changing the release flow; no active exploitation is known or claimed.

## Reviewers’ hat-rack :tophat:

- [ ] Confirm the release job only needs repository read access plus OIDC token issuance.
- [ ] Confirm npm trusted publishing remains unchanged.

Verification:

- Workflow YAML parses successfully.
- The parsed job permissions are exactly `contents: read` and `id-token: write`.
- The repository baseline passes: 14 Jest suites / 187 tests, type-check, lint, and build.
- `git diff --check` passes.

No regression test was added because this is declarative token-permission scoping; the resulting permission map was checked directly.

## Screenshots or videos (if needed)

Not applicable.
